### PR TITLE
APR-82: Extract DNR client library from notebook into src/onkia/

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ pandas = ">1.5.0,<3.0.0"
 numpy = ">=1.18"
 seaborn = ">=0.11.2,<0.12"
 matplotlib = ">=3.4.3,<4"
+pydantic = ">=2.0"
+requests = ">=2.28"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.0"

--- a/src/onkia/__init__.py
+++ b/src/onkia/__init__.py
@@ -1,0 +1,37 @@
+from onkia.dnr_client import MnDnrLakeTopographyService
+from onkia.models import (
+    Access,
+    Bbox,
+    FishCatchSummary,
+    Lake,
+    Length,
+    Limit,
+    Morphology,
+    Reg,
+    Resource,
+    SpecialFishingReg,
+    Survey,
+    SurveyOverview,
+    WaterLevelReading,
+    WaterTempPreference,
+)
+from onkia.water_temp import WATER_TEMP_PREFERENCES
+
+__all__ = [
+    "MnDnrLakeTopographyService",
+    "Lake",
+    "Morphology",
+    "SpecialFishingReg",
+    "Reg",
+    "Resource",
+    "Bbox",
+    "SurveyOverview",
+    "Access",
+    "Survey",
+    "Length",
+    "FishCatchSummary",
+    "Limit",
+    "WaterLevelReading",
+    "WaterTempPreference",
+    "WATER_TEMP_PREFERENCES",
+]

--- a/src/onkia/dnr_client.py
+++ b/src/onkia/dnr_client.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import csv
+import io
+import logging
+from typing import Any, Dict, List, Mapping, Optional, Protocol
+
+import requests
+
+from onkia.models import Lake, SurveyOverview, WaterLevelReading
+
+
+class LakeTopographyService(Protocol):
+    def get_lake(self, name: str, county_id: int = 86) -> Optional[Lake]:
+        ...
+
+    def get_survey(self, lake_id: str) -> Optional[SurveyOverview]:
+        ...
+
+    def get_species(self, name: str, county_id: int = 86, state_id: int = 1) -> List[Dict[str, Any]]:
+        ...
+
+    def get_water_levels(self, lake_id: str) -> List[WaterLevelReading]:
+        ...
+
+    def get_stocking(self, lake_id: str) -> Any:
+        ...
+
+
+def _csv_to_dicts(data: str, delimiter: str = ",") -> List[Dict[str, str]]:
+    csvio = io.StringIO(data, newline="")
+    return list(csv.DictReader(csvio, delimiter=delimiter))
+
+
+class MnDnrLakeTopographyService:
+    _API_BY_NAME_AND_COUNTY = "http://services.dnr.state.mn.us/api/lakefinder/by_name/v1"
+    _API_MAP_HOST = "https://maps2.dnr.state.mn.us/cgi-bin/lakefinder/detail.cgi"
+    _API_SPECIES_REPORT = "https://maps2.dnr.state.mn.us/cgi-bin/fom.cgi"
+    _API_WATER_LEVELS_REPORT = "https://files.dnr.state.mn.us/cgi-bin/lk_levels_dump.cgi"
+    _API_STOCKING_REPORT = "https://files.dnr.state.mn.us/cgi-bin/lk_stocking.cgi"
+
+    def __init__(self, logger: Optional[logging.Logger] = None):
+        self._logger = logger or logging.getLogger(__name__)
+
+    def _send_request(
+        self,
+        endpoint: str,
+        params: Optional[Mapping[str, str]],
+    ) -> Any:
+        self._logger.debug("Sending request to %s", endpoint)
+        response = requests.get(endpoint, params=params)
+        response_json = response.json()
+        return response_json.get("results", response_json.get("result"))
+
+    def _send_csv_request(
+        self,
+        endpoint: str,
+        params: Optional[Mapping[str, str]],
+        delimiter: str = ",",
+    ) -> List[Dict[str, str]]:
+        self._logger.debug("Sending request to %s", endpoint)
+        raw_response = requests.get(endpoint, params=params)
+        return _csv_to_dicts(raw_response.text, delimiter=delimiter)
+
+    def get_lake(self, name: str, county_id: int = 86) -> Optional[Lake]:
+        results = self._send_request(
+            self._API_BY_NAME_AND_COUNTY,
+            params={"name": name, "county": str(county_id)},
+        )
+        if not results:
+            return None
+        raw = next(iter(results), None)
+        if raw is None:
+            return None
+        return Lake.model_validate(raw)
+
+    def get_survey(self, lake_id: str) -> Optional[SurveyOverview]:
+        raw = self._send_request(
+            self._API_MAP_HOST,
+            params={"type": "lake_survey", "id": lake_id},
+        )
+        if not raw:
+            return None
+        return SurveyOverview.model_validate(raw)
+
+    def get_species(
+        self,
+        name: str,
+        county_id: int = 86,
+        state_id: int = 1,
+    ) -> List[Dict[str, Any]]:
+        return self._send_csv_request(
+            self._API_SPECIES_REPORT,
+            params={
+                "wb_name": name,
+                "county_id": str(county_id),
+                "state_id": str(state_id),
+                "mode": "getdata",
+                "name": "csv",
+                "wb_type": "Lake",
+                "orderby": "",
+            },
+        )
+
+    def get_water_levels(self, lake_id: str) -> List[WaterLevelReading]:
+        raw_rows = self._send_csv_request(
+            self._API_WATER_LEVELS_REPORT,
+            params={"id": lake_id, "format": "csv"},
+        )
+        return [WaterLevelReading.model_validate(row) for row in raw_rows]
+
+    def get_depth(self, map_id: str) -> None:
+        return None
+
+    def get_stocking(self, lake_id: str) -> Any:
+        import xml.etree.ElementTree as ET
+
+        raw_response = requests.get(
+            self._API_STOCKING_REPORT,
+            params={"downum": lake_id},
+        )
+        root = ET.fromstring(raw_response.text)
+        self._logger.info("Stocking data retrieved for lake %s", lake_id)
+        return root

--- a/src/onkia/models.py
+++ b/src/onkia/models.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+def _to_camel(name: str) -> str:
+    parts = name.split("_")
+    return parts[0] + "".join(p.capitalize() for p in parts[1:])
+
+
+class OnkiaBaseModel(BaseModel):
+    model_config = ConfigDict(
+        alias_generator=_to_camel,
+        populate_by_name=True,
+        extra="ignore",
+    )
+
+
+class Morphology(OnkiaBaseModel):
+    area: float
+    max_depth: int
+    mean_depth: float
+    shore_length: float
+    littoral_area: float
+
+
+class Bbox(OnkiaBaseModel):
+    epsg4326: List[float] = Field(alias="epsg:4326")
+    epsg26915: List[int] = Field(alias="epsg:26915")
+
+
+class Reg(OnkiaBaseModel):
+    species: List[str]
+    text: str
+
+
+class SpecialFishingReg(OnkiaBaseModel):
+    location: str
+    loc_display_type: int
+    regs: List[Reg]
+
+
+class Resource(OnkiaBaseModel):
+    lake_health: int
+    ice_out: int
+    fca: int
+    water_levels: int
+    water_access: int
+    water_quality: int
+    sentinel_lake: int
+    ice_in: int
+    lake_map: int
+    special_fishing_regs: int
+    lake_survey: int
+    fish_stocking: int
+
+
+class Lake(OnkiaBaseModel):
+    morphology: Morphology
+    border: str = ""
+    county_id: int
+    fish_species: List[str]
+    notes: str = ""
+    special_fishing_regs: List[SpecialFishingReg] = []
+    bbox: Bbox
+    apr_ids: List[str]
+    point: Bbox
+    county: str
+    mapid: List[str]
+    name: str
+    resources: Resource
+    nearest_town: str
+    id: str
+    invasive_species: List[str] = []
+
+
+class Access(OnkiaBaseModel):
+    lake_access_comments: str = ""
+    location: str = ""
+    owner_type_id: str
+    public_use_auth_code: str
+    access_type_id: str
+
+
+class Limit(OnkiaBaseModel):
+    fish_count: List[List[int]]
+    maximum_length: int
+    minimum_length: int
+
+
+class Length(OnkiaBaseModel):
+    wae: Optional[Limit] = None
+    blg: Optional[Limit] = None
+    blb: Optional[Limit] = None
+    pmk: Optional[Limit] = None
+    yeb: Optional[Limit] = None
+    gsf: Optional[Limit] = None
+    cap: Optional[Limit] = None
+    tlc: Optional[Limit] = None
+    yep: Optional[Limit] = None
+    bof: Optional[Limit] = None
+    lmb: Optional[Limit] = None
+    hsf: Optional[Limit] = None
+    blc: Optional[Limit] = None
+    brb: Optional[Limit] = None
+    rkb: Optional[Limit] = None
+    nop: Optional[Limit] = None
+    gos: Optional[Limit] = None
+    wts: Optional[Limit] = None
+
+
+class FishCatchSummary(OnkiaBaseModel):
+    quartile_count: str
+    cpue: Union[float, str] = Field(alias="CPUE")
+    species: str
+    total_catch: int
+    total_weight: Union[float, str]
+    quartile_weight: str
+    gear: str
+    average_weight: Union[float, str]
+    gear_count: Union[float, int]
+
+
+class Survey(OnkiaBaseModel):
+    survey_sub_type: str
+    lengths: Optional[Union[Length, dict]] = None
+    survey_type: str
+    survey_date: str
+    narrative: str = ""
+    survey_id: int
+    fish_catch_summaries: List[FishCatchSummary] = []
+    header_info: List[Optional[str]] = []
+
+
+class SurveyOverview(OnkiaBaseModel):
+    littoral_acres: float
+    accesses: List[Access] = []
+    mean_depth_feet: Optional[float] = None
+    max_depth_feet: int
+    area_acres: float
+    lake_name: str = ""
+    average_water_clarity: Union[float, str] = 0.0
+    surveys: List[Survey] = []
+    dow_number: int = 0
+    shore_length_miles: float
+    sampled_plants: List = []
+    water_clarity: List[List[Union[float, str]]] = []
+    office_code: str = ""
+
+
+class WaterLevelReading(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    chr_id: str = Field(alias="CHR_ID")
+    elevation: Union[float, str] = Field(alias="ELEVATION")
+    read_date: str = Field(alias="READ_DATE")
+    datum_adj: str = Field(alias="DATUM_ADJ")
+
+
+class WaterTempPreference(OnkiaBaseModel):
+    species: str
+    lower_avoidance: Optional[float] = None
+    optimum: str
+    upper_avoidance: Optional[float] = None

--- a/src/onkia/water_temp.py
+++ b/src/onkia/water_temp.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import List
+
+from onkia.models import WaterTempPreference
+
+_RAW_DATA = [
+    ("Atlantic Salmon", 45, "50-62", None),
+    ("Black Crappie", 60, "71", 75),
+    ("Bluegills", 58, "69-72", 80),
+    ("Blue Catfish", None, "77-82", None),
+    ("Brook Trout", 44, "58", 70),
+    ("Brown Bullhead", 65, "78-82", 85),
+    ("Brown Trout", 44, "56-66", 75),
+    ("Burbot", None, "52", None),
+    ("Channel Catfish", 55, "82-89", None),
+    ("Chinook Salmon", 44, "55", 60),
+    ("Coho Salmon", 44, "55", 60),
+    ("Flathead Catfish", 81, "85", 90),
+    ("Grayling", None, None, 65),
+    ("Lake Trout", 40, "50-55", 60),
+    ("Largemouth Bass", 50, "65-75", 85),
+    ("Muskellunge", 55, "63-67", 78),
+    ("Northern Pike", 55, "65", 74),
+    ("Pumpkinseed", None, "81", None),
+    ("Rainbow Trout", 44, "61", 75),
+    ("Rock Bass", None, "70", None),
+    ("Smallmouth Bass", 60, "65-70", 73),
+    ("Splake", 42, "50-66", 68),
+    ("Steelhead Trout", 38, "55-60", None),
+    ("Sunfish", 50, "58", 68),
+    ("Walleye", 50, "64-70", 76),
+    ("White Bass", 55, "65-70", 80),
+    ("White Catfish", None, "80-85", None),
+    ("White Crappie", None, "61", None),
+    ("White Perch", None, "89", None),
+    ("Yellow Perch", 58, "68", 75),
+]
+
+
+def _parse_preferences() -> List[WaterTempPreference]:
+    return [
+        WaterTempPreference(
+            species=species,
+            lower_avoidance=lower,
+            optimum=str(optimum) if optimum is not None else "N/A",
+            upper_avoidance=upper,
+        )
+        for species, lower, optimum, upper in _RAW_DATA
+    ]
+
+
+WATER_TEMP_PREFERENCES: List[WaterTempPreference] = _parse_preferences()

--- a/tests/test_dnr_client.py
+++ b/tests/test_dnr_client.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from onkia.dnr_client import MnDnrLakeTopographyService
+from onkia.models import (
+    FishCatchSummary,
+    Lake,
+    Morphology,
+    SpecialFishingReg,
+    Survey,
+    SurveyOverview,
+    WaterLevelReading,
+    WaterTempPreference,
+)
+from onkia.water_temp import WATER_TEMP_PREFERENCES
+
+
+@pytest.fixture
+def service():
+    return MnDnrLakeTopographyService()
+
+
+MOCK_LAKE_RAW = {
+    "morphology": {
+        "max_depth": 73,
+        "littoral_area": 1595.6,
+        "shore_length": 34.83,
+        "area": 3186.89,
+        "mean_depth": 19.2,
+    },
+    "point": {"epsg:26915": [412312, 5017445], "epsg:4326": [-94.118377, 45.305151]},
+    "id": "86025200",
+    "county_id": 86,
+    "nearest_town": "Annandale",
+    "bbox": {
+        "epsg:4326": [-94.167073, 45.276006, -94.069682, 45.334296],
+        "epsg:26915": [408510, 5014180, 416113, 5020710],
+    },
+    "name": "Clearwater",
+    "apr_ids": ["2009"],
+    "invasiveSpecies": ["Eurasian watermilfoil", "zebra mussel"],
+    "resources": {
+        "iceIn": 1,
+        "waterLevels": 1,
+        "lakeHealth": 1,
+        "waterAccess": 1,
+        "iceOut": 1,
+        "waterQuality": 0,
+        "fca": 1,
+        "specialFishingRegs": 1,
+        "lakeMap": 1,
+        "sentinelLake": 0,
+        "fishStocking": 1,
+        "lakeSurvey": 1,
+    },
+    "mapid": ["C0779"],
+    "border": "",
+    "fishSpecies": ["black crappie", "bluegill", "walleye"],
+    "county": "Wright",
+    "notes": "",
+    "specialFishingRegs": [
+        {
+            "location": "Including connected Clearwater and Grass lakes",
+            "locDisplayType": 1,
+            "regs": [
+                {"species": ["Crappie"], "text": "Daily limit five."},
+                {"species": ["Sunfish"], "text": "Daily limit ten."},
+            ],
+        }
+    ],
+}
+
+MOCK_SURVEY_RAW = {
+    "averageWaterClarity": "5.8",
+    "waterClarity": [["07/21/2014", "4.5"], ["08/01/2022", "6.5"]],
+    "littoralAcres": 1595.6,
+    "sampledPlants": [],
+    "areaAcres": 3186.89,
+    "maxDepthFeet": 73,
+    "shoreLengthMiles": 34.83,
+    "officeCode": "F315",
+    "dowNumber": 86025200,
+    "surveys": [
+        {
+            "surveySubType": "",
+            "surveyType": "Standard Survey",
+            "surveyDate": "2014-07-21",
+            "narrative": "",
+            "surveyId": 12345,
+            "fishCatchSummaries": [
+                {
+                    "gearCount": 20,
+                    "averageWeight": "0.55",
+                    "totalWeight": 6.1,
+                    "gear": "Standard trap nets",
+                    "CPUE": "0.55",
+                    "quartileCount": "0.3-2.1",
+                    "quartileWeight": "0.4-0.8",
+                    "species": "BLB",
+                    "totalCatch": 11,
+                }
+            ],
+            "headerInfo": [None],
+        }
+    ],
+}
+
+MOCK_WATER_LEVELS_CSV = (
+    "CHR_ID,ELEVATION,READ_DATE,DATUM_ADJ\r\n"
+    "86025200,990.58,1932-01-01,NGVD 29\r\n"
+    "86025200,991.05,1939-01-01,NGVD 29\r\n"
+)
+
+MOCK_SPECIES_CSV = (
+    "FOM ID,Scientific Name,Common Name,Gear,Catch\r\n"
+    "433927,Ambloplites rupestris,rock bass,Gill net (all),42\r\n"
+)
+
+
+class TestGetLake:
+    @patch("onkia.dnr_client.requests.get")
+    def test_returns_lake_model(self, mock_get, service):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": [MOCK_LAKE_RAW]}
+        mock_get.return_value = mock_response
+
+        lake = service.get_lake("Clearwater", county_id=86)
+
+        assert isinstance(lake, Lake)
+        assert lake.name == "Clearwater"
+        assert lake.county_id == 86
+        assert lake.id == "86025200"
+        assert lake.morphology.max_depth == 73
+        assert lake.morphology.area == 3186.89
+
+    @patch("onkia.dnr_client.requests.get")
+    def test_passes_correct_params(self, mock_get, service):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": [MOCK_LAKE_RAW]}
+        mock_get.return_value = mock_response
+
+        service.get_lake("Clearwater", county_id=86)
+
+        mock_get.assert_called_once_with(
+            MnDnrLakeTopographyService._API_BY_NAME_AND_COUNTY,
+            params={"name": "Clearwater", "county": "86"},
+        )
+
+    @patch("onkia.dnr_client.requests.get")
+    def test_returns_none_when_empty_results(self, mock_get, service):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": []}
+        mock_get.return_value = mock_response
+
+        assert service.get_lake("Nonexistent") is None
+
+    @patch("onkia.dnr_client.requests.get")
+    def test_handles_invasive_species(self, mock_get, service):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": [MOCK_LAKE_RAW]}
+        mock_get.return_value = mock_response
+
+        lake = service.get_lake("Clearwater")
+        assert "Eurasian watermilfoil" in lake.invasive_species
+
+    @patch("onkia.dnr_client.requests.get")
+    def test_handles_special_fishing_regs(self, mock_get, service):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": [MOCK_LAKE_RAW]}
+        mock_get.return_value = mock_response
+
+        lake = service.get_lake("Clearwater")
+        assert len(lake.special_fishing_regs) == 1
+        assert lake.special_fishing_regs[0].regs[0].species == ["Crappie"]
+
+
+class TestGetSurvey:
+    @patch("onkia.dnr_client.requests.get")
+    def test_returns_survey_overview(self, mock_get, service):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"result": MOCK_SURVEY_RAW}
+        mock_get.return_value = mock_response
+
+        survey = service.get_survey("86025200")
+
+        assert isinstance(survey, SurveyOverview)
+        assert survey.max_depth_feet == 73
+        assert survey.area_acres == 3186.89
+        assert len(survey.surveys) == 1
+
+    @patch("onkia.dnr_client.requests.get")
+    def test_survey_fish_catch_summaries(self, mock_get, service):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"result": MOCK_SURVEY_RAW}
+        mock_get.return_value = mock_response
+
+        survey = service.get_survey("86025200")
+        catch = survey.surveys[0].fish_catch_summaries[0]
+        assert isinstance(catch, FishCatchSummary)
+        assert catch.species == "BLB"
+        assert catch.total_catch == 11
+
+
+class TestGetSpecies:
+    @patch("onkia.dnr_client.requests.get")
+    def test_returns_list_of_dicts(self, mock_get, service):
+        mock_response = MagicMock()
+        mock_response.text = MOCK_SPECIES_CSV
+        mock_get.return_value = mock_response
+
+        species = service.get_species("Clearwater")
+
+        assert len(species) == 1
+        assert species[0]["Common Name"] == "rock bass"
+        assert species[0]["Catch"] == "42"
+
+
+class TestGetWaterLevels:
+    @patch("onkia.dnr_client.requests.get")
+    def test_returns_water_level_readings(self, mock_get, service):
+        mock_response = MagicMock()
+        mock_response.text = MOCK_WATER_LEVELS_CSV
+        mock_get.return_value = mock_response
+
+        levels = service.get_water_levels("86025200")
+
+        assert len(levels) == 2
+        assert all(isinstance(l, WaterLevelReading) for l in levels)
+        assert float(levels[0].elevation) == 990.58
+        assert levels[0].datum_adj == "NGVD 29"
+
+
+class TestGetDepth:
+    def test_returns_none(self, service):
+        assert service.get_depth("C0779") is None
+
+
+class TestWaterTempPreferences:
+    def test_count(self):
+        assert len(WATER_TEMP_PREFERENCES) == 30
+
+    def test_first_entry(self):
+        assert WATER_TEMP_PREFERENCES[0].species == "Atlantic Salmon"
+        assert WATER_TEMP_PREFERENCES[0].lower_avoidance == 45
+        assert WATER_TEMP_PREFERENCES[0].optimum == "50-62"
+        assert WATER_TEMP_PREFERENCES[0].upper_avoidance is None
+
+    def test_walleye(self):
+        wae = next(w for w in WATER_TEMP_PREFERENCES if w.species == "Walleye")
+        assert wae.lower_avoidance == 50
+        assert wae.optimum == "64-70"
+        assert wae.upper_avoidance == 76
+
+    def test_all_are_water_temp_preference(self):
+        assert all(isinstance(w, WaterTempPreference) for w in WATER_TEMP_PREFERENCES)
+
+
+class TestModels:
+    def test_lake_from_camelCase(self):
+        lake = Lake.model_validate(MOCK_LAKE_RAW)
+        assert lake.name == "Clearwater"
+        assert lake.county_id == 86
+        assert lake.invasive_species == ["Eurasian watermilfoil", "zebra mussel"]
+
+    def test_survey_overview_from_camelCase(self):
+        survey = SurveyOverview.model_validate(MOCK_SURVEY_RAW)
+        assert survey.max_depth_feet == 73
+        assert survey.office_code == "F315"
+        assert survey.dow_number == 86025200
+
+    def test_water_level_reading(self):
+        reading = WaterLevelReading(
+            chr_id="86025200",
+            elevation=990.58,
+            read_date="1932-01-01",
+            datum_adj="NGVD 29",
+        )
+        assert reading.chr_id == "86025200"
+        assert reading.elevation == 990.58
+
+    def test_fish_catch_summary_handles_string_cpue(self):
+        catch = FishCatchSummary(
+            quartile_count="0.3-2.1",
+            cpue="0.55",
+            species="BLB",
+            total_catch=11,
+            total_weight="6.1",
+            quartile_weight="0.4-0.8",
+            gear="Standard trap nets",
+            average_weight="0.55",
+            gear_count=20,
+        )
+        assert catch.cpue == "0.55"


### PR DESCRIPTION
## Summary

- Extract `MnDnrLakeTopographyService` from `notebooks/onkia.ipynb` into `src/onkia/dnr_client.py` with methods for lake lookup, survey data, species, water levels, and stocking
- Create `src/onkia/models.py` with Pydantic v2 models for all API response shapes (Lake, SurveyOverview, FishCatchSummary, WaterLevelReading, etc.), with camelCase alias generation for API compatibility
- Create `src/onkia/water_temp.py` with structured water temperature preference data as Pydantic models
- Create `tests/test_dnr_client.py` with 18 unit tests covering all client methods with mocked API responses
- Update `pyproject.toml` with pydantic and requests dependencies

## Test Plan

- [x] All 18 unit tests pass (`PYTHONPATH=src pytest tests/test_dnr_client.py`)
- [x] Models correctly parse camelCase API responses (with `alias_generator`)
- [x] Bbox model handles `epsg:4326`/`epsg:26915` colon-separated keys
- [x] FishCatchSummary handles `CPUE` uppercase alias
- [x] WaterLevelReading handles uppercase CSV column aliases

Closes: APR-82