### PR TITLE
feat: Marimo exploration notebooks for Wright County lakes (APR-84)

### DIFF
--- a/notebooks/01_data_exploration.py
+++ b/notebooks/01_data_exploration.py
@@ -1,0 +1,211 @@
+"""
+Run this notebook:
+    marimo edit notebooks/01_data_exploration.py   # interactive UI
+    python notebooks/01_data_exploration.py        # CI / script mode (no data fetched)
+"""
+
+import marimo
+
+__generated_with = "0.11.0"
+app = marimo.App(width="medium", title="Wright County Lakes — Data Exploration")
+
+
+@app.cell
+def _setup_path():
+    import sys
+    import pathlib
+
+    _src = pathlib.Path(__file__).parent.parent / "src"
+    if str(_src) not in sys.path:
+        sys.path.insert(0, str(_src))
+    return
+
+
+@app.cell
+def _imports():
+    import marimo as mo
+    import pandas as pd
+    return mo, pd
+
+
+@app.cell
+def _header(mo):
+    mo.md("""
+    # Wright County Lakes — Data Exploration
+
+    Load lake metadata, survey data, and water levels for any lake in
+    **Wright County, Minnesota** (county ID 86) from the MN DNR LakeFinder API.
+
+    Select a lake and click **Load lake data** to begin.
+    """)
+    return
+
+
+@app.cell
+def _controls(mo):
+    WRIGHT_COUNTY_LAKES = [
+        "Clearwater", "Sylvia", "Pulaski", "Charlotte", "Beebe",
+        "Ann", "Constance", "Martha", "Ida", "Frances",
+        "Twin", "Eagle", "Bass", "Pleasant", "French",
+        "Silver", "Waverly", "Pelican", "Lime", "Indian",
+    ]
+
+    lake_select = mo.ui.dropdown(
+        options=WRIGHT_COUNTY_LAKES,
+        value="Clearwater",
+        label="Lake",
+    )
+    reload_btn = mo.ui.run_button(label="Load lake data")
+
+    mo.hstack([lake_select, reload_btn], gap=2, align="end")
+    return WRIGHT_COUNTY_LAKES, lake_select, reload_btn
+
+
+@app.cell
+def _load_data(mo, lake_select, reload_btn):
+    mo.stop(
+        not reload_btn.value,
+        mo.callout(
+            mo.md("Select a lake above and click **Load lake data** to fetch from the DNR API."),
+            kind="info",
+        ),
+    )
+
+    from onkia import MnDnrLakeTopographyService
+
+    _svc = MnDnrLakeTopographyService()
+    _name = lake_select.value
+
+    lake = _svc.get_lake(_name, county_id=86)
+    survey = _svc.get_survey(lake.id) if lake else None
+    water_levels = _svc.get_water_levels(lake.id) if lake else []
+
+    return lake, survey, water_levels
+
+
+@app.cell
+def _lake_summary(mo, lake):
+    if lake is None:
+        mo.callout(mo.md("Lake not found. Try a different name."), kind="warn")
+    else:
+        mo.md(f"""
+        ## {lake.name}
+
+        | Field | Value |
+        |---|---|
+        | County | {lake.county} |
+        | Nearest Town | {lake.nearest_town} |
+        | Area (acres) | {lake.morphology.area:,.1f} |
+        | Max Depth (ft) | {lake.morphology.max_depth} |
+        | Mean Depth (ft) | {lake.morphology.mean_depth:.1f} |
+        | Shore Length (mi) | {lake.morphology.shore_length:.2f} |
+        | Littoral Area (acres) | {lake.morphology.littoral_area:.1f} |
+        | Fish Species | {", ".join(lake.fish_species) if lake.fish_species else "None listed"} |
+        | Invasive Species | {", ".join(lake.invasive_species) if lake.invasive_species else "None reported"} |
+        """)
+    return
+
+
+@app.cell
+def _map(mo, lake):
+    if lake is None:
+        return
+
+    import folium
+
+    # point.epsg4326 is [lon, lat]
+    _coords = lake.point.epsg4326
+    _lat, _lon = _coords[1], _coords[0]
+
+    _m = folium.Map(location=[_lat, _lon], zoom_start=13)
+    folium.Marker(
+        location=[_lat, _lon],
+        popup=folium.Popup(
+            f"<b>{lake.name}</b><br>"
+            f"Area: {lake.morphology.area:,.1f} acres<br>"
+            f"Max Depth: {lake.morphology.max_depth} ft<br>"
+            f"Nearest Town: {lake.nearest_town}",
+            max_width=250,
+        ),
+        tooltip=lake.name,
+        icon=folium.Icon(color="blue", icon="tint", prefix="fa"),
+    ).add_to(_m)
+
+    mo.Html(_m._repr_html_())
+    return
+
+
+@app.cell
+def _survey_overview(mo, survey):
+    if survey is None:
+        mo.md("No survey data available.")
+    else:
+        mo.md(f"""
+        ## Survey Overview
+
+        | Field | Value |
+        |---|---|
+        | Area (acres) | {survey.area_acres:,.1f} |
+        | Max Depth (ft) | {survey.max_depth_feet} |
+        | Mean Depth (ft) | {survey.mean_depth_feet if survey.mean_depth_feet is not None else "N/A"} |
+        | Shore Length (mi) | {survey.shore_length_miles:.2f} |
+        | Littoral Acres | {survey.littoral_acres:.1f} |
+        | Avg Water Clarity (ft) | {survey.average_water_clarity} |
+        | Surveys on record | {len(survey.surveys)} |
+        | Public Accesses | {len(survey.accesses)} |
+        """)
+    return
+
+
+@app.cell
+def _catch_table(mo, pd, survey):
+    if survey is None or not survey.surveys:
+        mo.md("No fish catch data available.")
+    else:
+        _rows = []
+        for _s in survey.surveys:
+            for _f in _s.fish_catch_summaries:
+                _rows.append({
+                    "Survey Date": _s.survey_date,
+                    "Survey Type": _s.survey_type,
+                    "Species": _f.species,
+                    "Total Catch": _f.total_catch,
+                    "CPUE": _f.cpue,
+                    "Avg Weight (lbs)": _f.average_weight,
+                    "Gear": _f.gear,
+                })
+
+        if _rows:
+            _df = pd.DataFrame(_rows).sort_values("Survey Date", ascending=False)
+            mo.vstack([
+                mo.md(f"## Fish Catch Summaries ({len(_rows)} records across {len(survey.surveys)} surveys)"),
+                mo.ui.table(_df, pagination=True),
+            ])
+        else:
+            mo.md("No fish catch summaries in the survey data.")
+    return
+
+
+@app.cell
+def _water_levels(mo, pd, water_levels):
+    if not water_levels:
+        mo.md("No water level data available.")
+    else:
+        _df = pd.DataFrame([
+            {
+                "Date": wl.read_date,
+                "Elevation": wl.elevation,
+                "Datum Adj": wl.datum_adj,
+            }
+            for wl in water_levels
+        ]).sort_values("Date", ascending=False)
+
+        mo.vstack([
+            mo.md(f"## Water Level History ({len(_df)} readings)"),
+            mo.ui.table(_df.head(100), pagination=True),
+        ])
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/notebooks/02_species_analysis.py
+++ b/notebooks/02_species_analysis.py
@@ -1,0 +1,240 @@
+"""
+Run this notebook:
+    marimo edit notebooks/02_species_analysis.py   # interactive UI
+    python notebooks/02_species_analysis.py        # CI / script mode (no data fetched)
+"""
+
+import marimo
+
+__generated_with = "0.11.0"
+app = marimo.App(width="medium", title="Wright County — Species Catch Trends")
+
+
+@app.cell
+def _setup_path():
+    import sys
+    import pathlib
+
+    _src = pathlib.Path(__file__).parent.parent / "src"
+    if str(_src) not in sys.path:
+        sys.path.insert(0, str(_src))
+    return
+
+
+@app.cell
+def _imports():
+    import marimo as mo
+    import pandas as pd
+    return mo, pd
+
+
+@app.cell
+def _header(mo):
+    mo.md("""
+    # Wright County — Species Catch Trends
+
+    Explore fish catch trends over time for target species across Wright County lakes,
+    using occurrence records from the MN DNR Fishes of Minnesota (FOM) database.
+
+    **Target species:** Largemouth Bass · Northern Pike · Sunfish · Crappie · Walleye
+    """)
+    return
+
+
+@app.cell
+def _controls(mo):
+    WRIGHT_COUNTY_LAKES = [
+        "Clearwater", "Sylvia", "Pulaski", "Charlotte", "Beebe",
+        "Ann", "Constance", "Martha", "Ida", "Frances",
+        "Twin", "Eagle", "Bass", "Pleasant", "French",
+        "Silver", "Waverly", "Pelican", "Lime", "Indian",
+    ]
+
+    # Target species groups
+    TARGET_SPECIES = {
+        "Largemouth Bass": ["largemouth bass"],
+        "Northern Pike": ["northern pike"],
+        "Sunfish (all)": ["bluegill", "pumpkinseed", "green sunfish", "hybrid sunfish", "sunfish"],
+        "Black Crappie": ["black crappie"],
+        "White Crappie": ["white crappie"],
+        "Walleye": ["walleye"],
+    }
+
+    lake_select = mo.ui.dropdown(
+        options=WRIGHT_COUNTY_LAKES,
+        value="Clearwater",
+        label="Lake",
+    )
+    species_select = mo.ui.multiselect(
+        options=list(TARGET_SPECIES.keys()),
+        value=["Largemouth Bass", "Northern Pike", "Walleye", "Black Crappie"],
+        label="Species to display",
+    )
+    reload_btn = mo.ui.run_button(label="Load species data")
+
+    mo.vstack([
+        mo.hstack([lake_select, reload_btn], gap=2, align="end"),
+        species_select,
+    ])
+    return WRIGHT_COUNTY_LAKES, TARGET_SPECIES, lake_select, reload_btn, species_select
+
+
+@app.cell
+def _load_data(mo, lake_select, reload_btn):
+    mo.stop(
+        not reload_btn.value,
+        mo.callout(
+            mo.md("Select a lake and species above, then click **Load species data**."),
+            kind="info",
+        ),
+    )
+
+    from onkia import MnDnrLakeTopographyService
+
+    _svc = MnDnrLakeTopographyService()
+    raw_species = _svc.get_species(lake_select.value, county_id=86, state_id=1)
+    lake_name_loaded = lake_select.value
+
+    return raw_species, lake_name_loaded
+
+
+@app.cell
+def _build_df(mo, pd, raw_species, lake_name_loaded):
+    import warnings
+
+    if not raw_species:
+        mo.callout(mo.md("No species data returned. Try a different lake."), kind="warn")
+        species_df = pd.DataFrame()
+    else:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            _df = pd.DataFrame(raw_species)
+
+        # Strip leading/trailing spaces from all column names
+        _df.columns = [c.strip() for c in _df.columns]
+
+        # Parse key columns
+        _df["catch"] = pd.to_numeric(_df.get("Catch", _df.get(" Catch", pd.Series(dtype=float))), errors="coerce")
+        _df["date"] = pd.to_datetime(
+            _df.get("Date", _df.get(" Date", pd.Series(dtype=str))),
+            errors="coerce",
+        )
+        _df["common_name"] = (
+            _df.get("Common Name", _df.get(" Common Name", pd.Series(dtype=str)))
+            .str.strip()
+            .str.lower()
+        )
+        _df["year"] = _df["date"].dt.year
+
+        species_df = _df[["date", "year", "common_name", "catch"]].dropna(subset=["date", "common_name"])
+
+    return species_df,
+
+
+@app.cell
+def _filter_df(mo, pd, species_df, species_select, TARGET_SPECIES):
+    import itertools
+
+    if species_df.empty:
+        filtered_df = pd.DataFrame()
+        mo.md("No data to display.")
+    else:
+        # Build set of lowercase species names matching the selected groups
+        _selected_names = set(itertools.chain.from_iterable(
+            TARGET_SPECIES.get(grp, []) for grp in species_select.value
+        ))
+
+        # Map each row's common_name to its group label
+        _name_to_group = {}
+        for _group, _names in TARGET_SPECIES.items():
+            for _n in _names:
+                _name_to_group[_n] = _group
+
+        filtered_df = species_df[species_df["common_name"].isin(_selected_names)].copy()
+        filtered_df["species_group"] = filtered_df["common_name"].map(_name_to_group)
+
+    return filtered_df,
+
+
+@app.cell
+def _trend_chart(mo, pd, filtered_df, lake_name_loaded):
+    import matplotlib
+    import matplotlib.pyplot as plt
+    import matplotlib.dates as mdates
+
+    if filtered_df.empty:
+        mo.md("No matching species records to plot.")
+    else:
+        # Aggregate by year + species_group: sum catch per survey year
+        _agg = (
+            filtered_df.groupby(["year", "species_group"], as_index=False)["catch"]
+            .sum()
+            .sort_values("year")
+        )
+
+        _fig, _ax = plt.subplots(figsize=(12, 5))
+
+        for _grp, _data in _agg.groupby("species_group"):
+            _ax.plot(_data["year"], _data["catch"], marker="o", label=_grp, linewidth=2)
+
+        _ax.set_title(f"Species Catch Trends — {lake_name_loaded} Lake (Wright County)", fontsize=14)
+        _ax.set_xlabel("Year")
+        _ax.set_ylabel("Total Catch (all gear types)")
+        _ax.legend(title="Species", bbox_to_anchor=(1.01, 1), loc="upper left")
+        _ax.grid(True, alpha=0.3)
+        _fig.tight_layout()
+
+        plt.gca()
+        _fig
+    return
+
+
+@app.cell
+def _summary_table(mo, pd, filtered_df):
+    if filtered_df.empty:
+        return
+
+    _summary = (
+        filtered_df.groupby("species_group")
+        .agg(
+            surveys=("date", "nunique"),
+            total_catch=("catch", "sum"),
+            avg_catch_per_survey=("catch", "mean"),
+            max_catch=("catch", "max"),
+            first_recorded=("date", "min"),
+            last_recorded=("date", "max"),
+        )
+        .reset_index()
+        .rename(columns={"species_group": "Species Group"})
+        .sort_values("total_catch", ascending=False)
+    )
+
+    _summary["avg_catch_per_survey"] = _summary["avg_catch_per_survey"].round(1)
+    _summary["first_recorded"] = _summary["first_recorded"].dt.strftime("%Y-%m-%d")
+    _summary["last_recorded"] = _summary["last_recorded"].dt.strftime("%Y-%m-%d")
+
+    mo.vstack([
+        mo.md("## Summary by Species Group"),
+        mo.ui.table(_summary),
+    ])
+    return
+
+
+@app.cell
+def _raw_records_table(mo, pd, filtered_df):
+    if filtered_df.empty:
+        return
+
+    _display = filtered_df.copy()
+    _display["date"] = _display["date"].dt.strftime("%Y-%m-%d")
+    _display = _display.sort_values("date", ascending=False)
+
+    mo.vstack([
+        mo.md(f"## All Matching Records ({len(_display)} rows)"),
+        mo.ui.table(_display[["date", "species_group", "common_name", "catch"]], pagination=True),
+    ])
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/notebooks/03_lake_day_analysis.py
+++ b/notebooks/03_lake_day_analysis.py
@@ -1,0 +1,357 @@
+"""
+Run this notebook:
+    marimo edit notebooks/03_lake_day_analysis.py   # interactive UI
+    python notebooks/03_lake_day_analysis.py        # CI / script mode (no data fetched)
+
+Given a lake and a date, this notebook shows:
+  - Water temperature preference match for each target species
+  - Most recent survey fish catch data
+  - Stocking history
+  - Fishing technique recommendations
+"""
+
+import marimo
+
+__generated_with = "0.11.0"
+app = marimo.App(width="medium", title="Lake Day Analysis — Wright County")
+
+
+@app.cell
+def _setup_path():
+    import sys
+    import pathlib
+
+    _src = pathlib.Path(__file__).parent.parent / "src"
+    if str(_src) not in sys.path:
+        sys.path.insert(0, str(_src))
+    return
+
+
+@app.cell
+def _imports():
+    import marimo as mo
+    import pandas as pd
+    import datetime
+    return datetime, mo, pd
+
+
+# ---------------------------------------------------------------------------
+# Fishing technique lookup keyed by (species, temp_zone)
+# temp_zone: "cold" = below lower avoidance, "cool" = between lower and optimum,
+#            "optimal" = within optimum range, "warm" = above optimum, "hot" = above upper avoidance
+# ---------------------------------------------------------------------------
+_TECHNIQUES = {
+    "Largemouth Bass": {
+        "cold":    ["Slow-roll finesse jigs near bottom structure", "Drop-shot with small finesse worm"],
+        "cool":    ["Slow-twitched jerkbaits", "Ned rig on rocky points", "Swim jigs along weed edges"],
+        "optimal": ["Topwater frogs/poppers over vegetation", "Texas-rigged plastic worm", "Spinnerbait along weedlines", "Hollow-body frog in lily pads"],
+        "warm":    ["Deep-diving crankbaits", "Carolina rig on main-lake structure", "Football jig"],
+        "hot":     ["Very early morning topwater", "Deep shade structure with drop-shot"],
+    },
+    "Northern Pike": {
+        "cold":    ["Large jigging spoons near bottom", "Slow-twitched jerkbaits in deep water"],
+        "cool":    ["Jerkbaits along weed edges", "Bucktail spinners", "Live sucker rigs"],
+        "optimal": ["Large spinnerbaits", "Flashy spoons over weedlines", "Swimbaits", "Top-water gliders"],
+        "warm":    ["Deep-running crankbaits", "Vertical jigging in deepest cool water"],
+        "hot":     ["Target deep, cool water only; pike inactive near surface"],
+    },
+    "Black Crappie": {
+        "cold":    ["Small tube jigs tipped with waxworm, fished very slowly"],
+        "cool":    ["Small jigs (1/16 oz) under slip float", "Micro-spoons"],
+        "optimal": ["Small jig under bobber near brush piles", "Minnow under slip float", "Vertical jigging with small spoon"],
+        "warm":    ["Night fishing with light near docks", "Small jig in deeper water"],
+        "hot":     ["Night fishing with lights", "Brush-pile fishing in 12–18 ft"],
+    },
+    "Sunfish": {
+        "cold":    ["Tiny jig tipped with waxworm under bobber"],
+        "cool":    ["Small beetle-spin", "Wax worm under bobber near weeds"],
+        "optimal": ["Small jig or fly under bobber", "Cricket on light hook", "Small spinner in shallow weeds"],
+        "warm":    ["Small jig near deeper weed edges", "Live bait under dock shade"],
+        "hot":     ["Live crickets near shade", "Early morning in shallow weeds"],
+    },
+    "Walleye": {
+        "cold":    ["Jigging spoon tipped with minnow in deep holes"],
+        "cool":    ["Jig-and-minnow along rock structure", "Live minnow under slip bobber on points"],
+        "optimal": ["Jig-and-minnow on main-lake structure", "Crawler harness trolled at 1.2–1.5 mph", "Slip bobber with leech near breaklines"],
+        "warm":    ["Night fishing along rocky shorelines", "Deep-water crawler harness trolling"],
+        "hot":     ["Night fishing only; deep main-lake structure during day"],
+    },
+}
+
+# Seasonal water temperature estimates for Wright County, MN (°F), by month
+_SEASONAL_TEMP = {1: 33, 2: 33, 3: 36, 4: 46, 5: 58, 6: 68, 7: 78, 8: 76, 9: 67, 10: 55, 11: 44, 12: 36}
+
+
+@app.cell
+def _header(mo):
+    mo.md("""
+    # Lake Day Analysis — Wright County
+
+    Enter a lake, date, and optional water temperature to get fishing guidance:
+    water temperature suitability per species, recent survey catch data,
+    stocking history, and technique recommendations.
+    """)
+    return
+
+
+@app.cell
+def _controls(mo, datetime):
+    WRIGHT_COUNTY_LAKES = [
+        "Clearwater", "Sylvia", "Pulaski", "Charlotte", "Beebe",
+        "Ann", "Constance", "Martha", "Ida", "Frances",
+        "Twin", "Eagle", "Bass", "Pleasant", "French",
+        "Silver", "Waverly", "Pelican", "Lime", "Indian",
+    ]
+
+    lake_select = mo.ui.dropdown(
+        options=WRIGHT_COUNTY_LAKES,
+        value="Clearwater",
+        label="Lake",
+    )
+    date_input = mo.ui.date(
+        value=datetime.date.today(),
+        label="Date",
+    )
+    water_temp_input = mo.ui.number(
+        start=32,
+        stop=95,
+        step=1,
+        value=0,
+        label="Water temp (°F, 0 = estimate from date)",
+    )
+    reload_btn = mo.ui.run_button(label="Analyze")
+
+    mo.vstack([
+        mo.hstack([lake_select, date_input, water_temp_input, reload_btn], gap=2, align="end"),
+        mo.md("*Set water temp to 0 to use a seasonal estimate based on the date.*"),
+    ])
+    return WRIGHT_COUNTY_LAKES, date_input, lake_select, reload_btn, water_temp_input
+
+
+@app.cell
+def _load_data(mo, lake_select, date_input, water_temp_input, reload_btn):
+    mo.stop(
+        not reload_btn.value,
+        mo.callout(
+            mo.md("Fill in the controls above and click **Analyze** to load data."),
+            kind="info",
+        ),
+    )
+
+    from onkia import MnDnrLakeTopographyService, WATER_TEMP_PREFERENCES
+    import xml.etree.ElementTree as ET
+
+    _svc = MnDnrLakeTopographyService()
+    _name = lake_select.value
+
+    lake = _svc.get_lake(_name, county_id=86)
+    survey = _svc.get_survey(lake.id) if lake else None
+
+    # Stocking data (XML)
+    _stocking_root = None
+    if lake:
+        try:
+            _stocking_root = _svc.get_stocking(lake.id)
+        except Exception:
+            _stocking_root = None
+
+    analysis_date = date_input.value
+    raw_water_temp = water_temp_input.value
+    water_temp_prefs = WATER_TEMP_PREFERENCES
+
+    return ET, analysis_date, lake, raw_water_temp, survey, water_temp_prefs, _stocking_root
+
+
+@app.cell
+def _compute_water_temp(mo, analysis_date, raw_water_temp):
+    import datetime
+
+    _month = analysis_date.month if hasattr(analysis_date, "month") else datetime.date.today().month
+    _seasonal = _SEASONAL_TEMP.get(_month, 60)
+
+    if raw_water_temp and raw_water_temp > 0:
+        water_temp_f = float(raw_water_temp)
+        temp_source = f"user-provided ({water_temp_f:.0f}°F)"
+    else:
+        water_temp_f = float(_seasonal)
+        temp_source = f"seasonal estimate for month {_month} ({water_temp_f:.0f}°F)"
+
+    mo.md(f"""
+    ## Conditions on {analysis_date}
+
+    **Water Temperature:** {water_temp_f:.0f}°F *(source: {temp_source})*
+    """)
+    return water_temp_f, temp_source
+
+
+@app.cell
+def _temp_preference_table(mo, pd, water_temp_f, water_temp_prefs):
+    TARGET_SPECIES_NAMES = [
+        "Largemouth Bass", "Northern Pike", "Black Crappie",
+        "Bluegills", "Sunfish", "Walleye",
+    ]
+
+    def _parse_optimum_range(optimum_str):
+        """Return (low, high) for the optimum range string like '65-75' or '64'."""
+        if not optimum_str or optimum_str == "N/A":
+            return None, None
+        parts = optimum_str.split("-")
+        try:
+            if len(parts) == 2:
+                return float(parts[0]), float(parts[1])
+            return float(parts[0]), float(parts[0])
+        except ValueError:
+            return None, None
+
+    def _temp_zone(pref, temp):
+        """Classify temp relative to species preferences."""
+        opt_low, opt_high = _parse_optimum_range(pref.optimum)
+        lower_av = pref.lower_avoidance
+        upper_av = pref.upper_avoidance
+
+        if upper_av is not None and temp > upper_av:
+            return "hot", "🔴 Above avoidance — avoid"
+        if opt_high is not None and opt_low is not None:
+            if opt_low <= temp <= opt_high:
+                return "optimal", "🟢 Optimal"
+        if lower_av is not None and temp < lower_av:
+            return "cold", "🔵 Below avoidance — very slow"
+        if opt_low is not None and temp < opt_low:
+            return "cool", "🟡 Below optimum — slower"
+        if opt_high is not None and temp > opt_high:
+            return "warm", "🟠 Above optimum — deeper/slower"
+        return "cool", "🟡 Below optimum — slower"
+
+    _rows = []
+    for _pref in water_temp_prefs:
+        if _pref.species not in TARGET_SPECIES_NAMES:
+            continue
+        _zone, _label = _temp_zone(_pref, water_temp_f)
+        _rows.append({
+            "Species": _pref.species,
+            "Lower Avoidance (°F)": _pref.lower_avoidance or "N/A",
+            "Optimum (°F)": _pref.optimum,
+            "Upper Avoidance (°F)": _pref.upper_avoidance or "N/A",
+            "Status at Current Temp": _label,
+            "_zone": _zone,
+        })
+
+    _df = pd.DataFrame(_rows)
+
+    mo.vstack([
+        mo.md("## Water Temperature Suitability"),
+        mo.ui.table(_df.drop(columns=["_zone"])),
+    ])
+    return
+
+
+@app.cell
+def _technique_recommendations(mo, water_temp_f, water_temp_prefs):
+    TARGET_SPECIES_NAMES = ["Largemouth Bass", "Northern Pike", "Black Crappie", "Bluegills", "Walleye"]
+
+    def _parse_optimum_range(optimum_str):
+        if not optimum_str or optimum_str == "N/A":
+            return None, None
+        parts = optimum_str.split("-")
+        try:
+            return (float(parts[0]), float(parts[1])) if len(parts) == 2 else (float(parts[0]), float(parts[0]))
+        except ValueError:
+            return None, None
+
+    def _zone(pref, temp):
+        opt_low, opt_high = _parse_optimum_range(pref.optimum)
+        lower_av = pref.lower_avoidance
+        upper_av = pref.upper_avoidance
+        if upper_av is not None and temp > upper_av:
+            return "hot"
+        if opt_low is not None and opt_high is not None and opt_low <= temp <= opt_high:
+            return "optimal"
+        if lower_av is not None and temp < lower_av:
+            return "cold"
+        if opt_low is not None and temp < opt_low:
+            return "cool"
+        return "warm"
+
+    # Map Bluegills to Sunfish in techniques table
+    _SPECIES_TO_TECHNIQUE_KEY = {
+        "Largemouth Bass": "Largemouth Bass",
+        "Northern Pike": "Northern Pike",
+        "Black Crappie": "Black Crappie",
+        "Bluegills": "Sunfish",
+        "Walleye": "Walleye",
+    }
+
+    _sections = []
+    for _pref in water_temp_prefs:
+        if _pref.species not in TARGET_SPECIES_NAMES:
+            continue
+        _z = _zone(_pref, water_temp_f)
+        _key = _SPECIES_TO_TECHNIQUE_KEY.get(_pref.species, _pref.species)
+        _tips = _TECHNIQUES.get(_key, {}).get(_z, ["General slow presentations near cover."])
+        _bullet_list = "\n".join(f"  - {t}" for t in _tips)
+        _sections.append(f"**{_pref.species}** *(optimum: {_pref.optimum}°F)*\n{_bullet_list}")
+
+    mo.vstack([
+        mo.md("## Fishing Technique Recommendations"),
+        mo.md("\n\n".join(_sections)),
+    ])
+    return
+
+
+@app.cell
+def _recent_surveys(mo, pd, survey):
+    if survey is None or not survey.surveys:
+        mo.md("No survey data available.")
+    else:
+        # Most recent 3 surveys
+        _recent = sorted(survey.surveys, key=lambda s: s.survey_date, reverse=True)[:3]
+
+        _sections = []
+        for _s in _recent:
+            _rows = [
+                {
+                    "Species": f.species,
+                    "Total Catch": f.total_catch,
+                    "CPUE": f.cpue,
+                    "Avg Weight (lbs)": f.average_weight,
+                    "Gear": f.gear,
+                }
+                for f in _s.fish_catch_summaries
+            ]
+            if _rows:
+                _df = pd.DataFrame(_rows).sort_values("Total Catch", ascending=False)
+                _sections.append(mo.vstack([
+                    mo.md(f"### Survey: {_s.survey_date} — {_s.survey_type}"),
+                    mo.ui.table(_df),
+                ]))
+            else:
+                _sections.append(mo.md(f"### Survey: {_s.survey_date} — no catch data"))
+
+        mo.vstack([mo.md("## Recent Survey Data (last 3 surveys)")] + _sections)
+    return
+
+
+@app.cell
+def _stocking_history(mo, pd, _stocking_root):
+    if _stocking_root is None:
+        mo.md("No stocking data available (or not supported for this lake).")
+    else:
+        _rows = []
+        for _record in _stocking_root.iter("item"):
+            _row = {child.tag: child.text for child in _record}
+            if _row:
+                _rows.append(_row)
+
+        if _rows:
+            _df = pd.DataFrame(_rows)
+            mo.vstack([
+                mo.md(f"## Stocking History ({len(_df)} records)"),
+                mo.ui.table(_df, pagination=True),
+            ])
+        else:
+            mo.md("Stocking XML parsed but no records found.")
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ requests = ">=2.28"
 great-expectations = "^0.18.0"
 streamlit = ">=1.28"
 streamlit-folium = ">=0.15"
-folium = ">=0.14"
+marimo = ">=0.11.0"
+folium = ">=0.14.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.0"


### PR DESCRIPTION
## Summary

- Adds `notebooks/01_data_exploration.py` — Marimo notebook to load any Wright County lake from the DNR API, display on an interactive Folium map, and explore lake metadata, survey catch summaries, and water level history
- Adds `notebooks/02_species_analysis.py` — species catch trends over time for LMB, NOP, sunfish, crappie, and walleye with time-series chart and summary table
- Adds `notebooks/03_lake_day_analysis.py` — given a lake + date, shows water temperature suitability, recent survey data, stocking history, and technique recommendations
- Adds `marimo >= 0.11.0` and `folium >= 0.14.0` to `pyproject.toml`

## Design

- Each notebook imports from `src/onkia/` (path setup handled via `sys.path` in the first cell)
- Data is loaded on-demand via `mo.ui.run_button()` + `mo.stop()` — no API calls until the user clicks
- Reactive: changing lake/date/species dropdowns triggers downstream cells to re-run
- Runnable as plain Python scripts for CI (`python notebooks/NNN_xxx.py` → exits cleanly without fetching data)

## Test plan

- [ ] `marimo edit notebooks/01_data_exploration.py` — select Clearwater, click Load, confirm map renders and tables populate
- [ ] `marimo edit notebooks/02_species_analysis.py` — select Clearwater + target species, confirm trend chart renders
- [ ] `marimo edit notebooks/03_lake_day_analysis.py` — select Clearwater + today's date, confirm temp suitability table and technique recommendations render
- [ ] `python notebooks/01_data_exploration.py` exits with code 0 (CI validation)
- [ ] `python notebooks/02_species_analysis.py` exits with code 0
- [ ] `python notebooks/03_lake_day_analysis.py` exits with code 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)