### PR TITLE
APR-153: Lake-specific CPUE trend analysis with traceable evidence

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -26,6 +26,7 @@ if str(_src) not in sys.path:
     sys.path.insert(0, str(_src))
 
 from components.dnr_map import WRIGHT_COUNTY_LAKES, build_lake_map  # noqa: E402
+from onkia.analysis import LakeAnalysis, TrendStatus, analyze_lake, parse_stocking_events  # noqa: E402
 from onkia.dnr_client import MnDnrLakeTopographyService  # noqa: E402
 from onkia.water_temp import WATER_TEMP_PREFERENCES  # noqa: E402
 from onkia.models import WaterTempPreference  # noqa: E402
@@ -306,6 +307,82 @@ def _load_stocking_xml(lake_id: str) -> str:
         return resp.text
     except Exception:
         return ""
+
+
+@st.cache_data(show_spinner="Computing trend analysis…")
+def _compute_trend_analysis(lake_id: str, lake_name: str) -> Optional[dict]:
+    """Run analyze_lake and return a JSON-serialisable dict for caching."""
+    try:
+        svc = MnDnrLakeTopographyService()
+        overview = svc.get_survey(lake_id)
+        if not overview:
+            return None
+        import requests as _req
+        import xml.etree.ElementTree as ET
+
+        try:
+            resp = _req.get(
+                "https://files.dnr.state.mn.us/cgi-bin/lk_stocking.cgi",
+                params={"downum": lake_id},
+                timeout=15,
+            )
+            xml_text = resp.text
+        except Exception:
+            xml_text = ""
+
+        # Parse stocking XML into record dicts (same logic as _parse_stocking)
+        stocking_records: List[Dict] = []
+        if xml_text.strip():
+            try:
+                root = ET.fromstring(xml_text)
+                for item in root.iter():
+                    if item.tag in ("stocking", "record", "row"):
+                        record = {child.tag: child.text for child in item}
+                        if record:
+                            stocking_records.append(record)
+            except ET.ParseError:
+                pass
+
+        analysis = analyze_lake(lake_name, overview, stocking_records=stocking_records)
+        # Serialise to plain dicts so st.cache_data can pickle it
+        return {
+            "lake_name": analysis.lake_name,
+            "species_trends": [
+                {
+                    "species": t.species,
+                    "status": t.status.value,
+                    "evidence": t.evidence,
+                    "latest_cpue": t.latest_cpue,
+                    "earliest_cpue": t.earliest_cpue,
+                    "survey_years": t.survey_years,
+                    "avg_weight_lbs": t.avg_weight_lbs,
+                    "avg_weight_trend": t.avg_weight_trend.value,
+                    "best_gear": t.best_gear,
+                }
+                for t in analysis.species_trends
+            ],
+            "water_clarity": (
+                {
+                    "status": analysis.water_clarity.status.value,
+                    "evidence": analysis.water_clarity.evidence,
+                    "recent_clarity_ft": analysis.water_clarity.recent_clarity_ft,
+                    "earliest_clarity_ft": analysis.water_clarity.earliest_clarity_ft,
+                }
+                if analysis.water_clarity
+                else None
+            ),
+            "stocking_events": [
+                {
+                    "species": e.species,
+                    "year": e.year,
+                    "quantity": e.quantity,
+                    "life_stage": e.life_stage,
+                }
+                for e in analysis.stocking_events
+            ],
+        }
+    except Exception:
+        return None
 
 
 @st.cache_data(show_spinner="Loading survey data for {lake_name}…")
@@ -744,6 +821,61 @@ if survey_data:
         st.info("No survey data available for this lake.")
 else:
     st.warning("Could not load survey data from DNR — API may be unavailable. The fishing recommendations above still work based on seasonal estimates.")
+
+st.divider()
+
+# --- Species Trend Analysis ---
+st.subheader("📈 Species Trend Analysis")
+st.caption("Population trends with traceable evidence from historical DNR surveys.")
+
+_trend_data = _compute_trend_analysis(lake_id, lake_name)
+
+if _trend_data and _trend_data.get("species_trends"):
+    _STATUS_ICON = {
+        "INCREASING": "🟢",
+        "DECREASING": "🔴",
+        "STABLE": "🟡",
+        "INSUFFICIENT_DATA": "⚪",
+    }
+    _STATUS_LABEL = {
+        "INCREASING": "Increasing",
+        "DECREASING": "Declining",
+        "STABLE": "Stable",
+        "INSUFFICIENT_DATA": "Insufficient data",
+    }
+
+    for trend in _trend_data["species_trends"]:
+        icon = _STATUS_ICON.get(trend["status"], "⚪")
+        label = _STATUS_LABEL.get(trend["status"], trend["status"])
+        with st.expander(f"{icon} **{trend['species']}** — {label}", expanded=True):
+            st.markdown(f"**Population trend:** {icon} {label}")
+            st.markdown(f"**Evidence:** {trend['evidence']}")
+
+            col_cpue, col_weight, col_gear = st.columns(3)
+            with col_cpue:
+                if trend["latest_cpue"] is not None:
+                    st.metric("Latest CPUE", f"{trend['latest_cpue']:.2f}")
+            with col_weight:
+                if trend["avg_weight_lbs"] is not None:
+                    wt_icon = _STATUS_ICON.get(trend["avg_weight_trend"], "⚪")
+                    st.metric("Avg Weight (lbs)", f"{trend['avg_weight_lbs']:.2f}", delta=f"{wt_icon} weight trend")
+            with col_gear:
+                if trend["best_gear"]:
+                    st.metric("Best Gear", trend["best_gear"])
+
+            if trend["survey_years"]:
+                years_str = ", ".join(str(y) for y in trend["survey_years"])
+                st.caption(f"Survey years with data: {years_str}")
+
+    # Water clarity section
+    if _trend_data.get("water_clarity"):
+        clarity = _trend_data["water_clarity"]
+        clarity_icon = _STATUS_ICON.get(clarity["status"], "⚪")
+        clarity_label = _STATUS_LABEL.get(clarity["status"], clarity["status"])
+        st.markdown(f"**Water Clarity:** {clarity_icon} {clarity_label}")
+        st.markdown(f"_{clarity['evidence']}_")
+else:
+    st.info("Trend analysis unavailable — DNR survey data could not be loaded.")
 
 st.divider()
 

--- a/src/onkia/analysis.py
+++ b/src/onkia/analysis.py
@@ -1,0 +1,396 @@
+"""CPUE trend analysis for lake-specific fishing intelligence.
+
+Computes population trend narratives with traceable evidence for
+each target species at a selected lake, using linear regression over
+historical survey data from the MN DNR.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, List, Optional, Tuple, Union
+
+import numpy as np
+
+from onkia.models import Survey, SurveyOverview
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+TARGET_SPECIES_CODES: Dict[str, List[str]] = {
+    "Walleye": ["WAE"],
+    "Northern Pike": ["NOP"],
+    "Largemouth Bass": ["LMB"],
+    "Black Crappie": ["BLC"],
+    "Sunfish": ["BLG", "GSF", "HSF", "PMK"],
+}
+
+# Minimum number of data points required to compute a trend
+MIN_SURVEYS_FOR_TREND = 3
+
+# |slope| < this fraction of mean CPUE per year → classified as STABLE
+_SLOPE_STABILITY_FRACTION = 0.05
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+class TrendStatus(str, Enum):
+    INCREASING = "INCREASING"
+    DECREASING = "DECREASING"
+    STABLE = "STABLE"
+    INSUFFICIENT_DATA = "INSUFFICIENT_DATA"
+
+
+@dataclass
+class SpeciesTrendSummary:
+    """Trend narrative for a single species at a lake, with traceable evidence."""
+
+    species: str
+    status: TrendStatus
+    # Human-readable evidence string citing survey years, CPUE values, and gear
+    evidence: str
+    latest_cpue: Optional[float]
+    earliest_cpue: Optional[float]
+    survey_years: List[int]
+    avg_weight_lbs: Optional[float]
+    avg_weight_trend: TrendStatus
+    best_gear: Optional[str]
+
+
+@dataclass
+class WaterClarityTrend:
+    """Secchi disk clarity trend with traceable evidence."""
+
+    status: TrendStatus
+    evidence: str
+    recent_clarity_ft: Optional[float]
+    earliest_clarity_ft: Optional[float]
+
+
+@dataclass
+class StockingEvent:
+    """A single fish stocking event parsed from DNR stocking records."""
+
+    species: str
+    year: int
+    quantity: Optional[int]
+    life_stage: str = ""
+
+
+@dataclass
+class LakeAnalysis:
+    """Complete trend analysis for all target species at a lake."""
+
+    lake_name: str
+    species_trends: List[SpeciesTrendSummary] = field(default_factory=list)
+    water_clarity: Optional[WaterClarityTrend] = None
+    stocking_events: List[StockingEvent] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Core trend computation
+# ---------------------------------------------------------------------------
+
+
+def _linear_slope(x: List[float], y: List[float]) -> float:
+    """Return the slope of the least-squares regression line through (x, y)."""
+    if len(x) < 2:
+        return 0.0
+    coeffs = np.polyfit(np.array(x, dtype=float), np.array(y, dtype=float), 1)
+    return float(coeffs[0])
+
+
+def compute_cpue_trend(
+    cpue_values: List[float],
+    years: List[int],
+    *,
+    stability_fraction: float = _SLOPE_STABILITY_FRACTION,
+) -> TrendStatus:
+    """Classify a CPUE time series as INCREASING, DECREASING, or STABLE.
+
+    Returns INSUFFICIENT_DATA when fewer than MIN_SURVEYS_FOR_TREND points exist.
+    The stability threshold is ``stability_fraction * mean(cpue)`` per year — changes
+    smaller than this are classified as STABLE rather than noise-driven trends.
+    """
+    if len(cpue_values) < MIN_SURVEYS_FOR_TREND:
+        return TrendStatus.INSUFFICIENT_DATA
+    mean_cpue = float(np.mean(cpue_values))
+    if mean_cpue == 0.0:
+        return TrendStatus.STABLE
+    slope = _linear_slope([float(y) for y in years], cpue_values)
+    threshold = stability_fraction * mean_cpue
+    if slope > threshold:
+        return TrendStatus.INCREASING
+    if slope < -threshold:
+        return TrendStatus.DECREASING
+    return TrendStatus.STABLE
+
+
+# ---------------------------------------------------------------------------
+# Survey data extraction helpers
+# ---------------------------------------------------------------------------
+
+
+def _collect_cpue_records(
+    surveys: List[Survey],
+    species_codes: List[str],
+) -> List[Tuple[int, float, float, str]]:
+    """Extract (year, cpue, avg_weight, gear) for the given species codes.
+
+    Only records with a positive, parseable CPUE are included.
+    Results are sorted by year ascending.
+    """
+    records: List[Tuple[int, float, float, str]] = []
+    for survey in surveys:
+        try:
+            year = int(str(survey.survey_date)[:4])
+        except (ValueError, TypeError, AttributeError):
+            continue
+        for catch in survey.fish_catch_summaries:
+            if catch.species not in species_codes:
+                continue
+            try:
+                cpue = float(catch.cpue)
+            except (ValueError, TypeError):
+                continue
+            if cpue <= 0:
+                continue
+            try:
+                avg_w = float(catch.average_weight)
+            except (ValueError, TypeError):
+                avg_w = float("nan")
+            records.append((year, cpue, avg_w, catch.gear or ""))
+    records.sort(key=lambda r: r[0])
+    return records
+
+
+def _best_gear(records: List[Tuple[int, float, float, str]]) -> Optional[str]:
+    """Return the gear type with the highest mean CPUE across all records."""
+    gear_totals: Dict[str, List[float]] = {}
+    for _, cpue, _, gear in records:
+        if gear:
+            gear_totals.setdefault(gear, []).append(cpue)
+    if not gear_totals:
+        return None
+    return max(gear_totals, key=lambda g: float(np.mean(gear_totals[g])))
+
+
+def _build_species_evidence(
+    species: str,
+    status: TrendStatus,
+    records: List[Tuple[int, float, float, str]],
+) -> str:
+    """Build a traceable evidence string citing survey years, CPUE values, and gear."""
+    if not records:
+        return f"No survey data found for {species}."
+    if status == TrendStatus.INSUFFICIENT_DATA:
+        years = sorted({r[0] for r in records})
+        year_str = ", ".join(str(y) for y in years)
+        return (
+            f"Only {len(records)} survey record(s) available "
+            f"(year(s): {year_str}) — insufficient for trend."
+        )
+    earliest_year, earliest_cpue = records[0][0], records[0][1]
+    latest_year, latest_cpue = records[-1][0], records[-1][1]
+    gear = _best_gear(records) or "surveys"
+    arrow = {"INCREASING": "↑", "DECREASING": "↓", "STABLE": "→"}.get(status.value, "")
+    return (
+        f"CPUE {earliest_cpue:.2f} → {latest_cpue:.2f} {arrow} "
+        f"over {earliest_year}–{latest_year} {gear} "
+        f"({len(records)} survey point(s))"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public analysis functions
+# ---------------------------------------------------------------------------
+
+
+def analyze_species_at_lake(
+    species_name: str,
+    species_codes: List[str],
+    surveys: List[Survey],
+) -> Optional[SpeciesTrendSummary]:
+    """Compute a trend summary for a single species across all surveys at a lake.
+
+    Returns None if the species has no data in any survey.
+    """
+    records = _collect_cpue_records(surveys, species_codes)
+    if not records:
+        return None
+
+    years = [r[0] for r in records]
+    cpue_values = [r[1] for r in records]
+    weight_values = [r[2] for r in records if not math.isnan(r[2])]
+
+    status = compute_cpue_trend(cpue_values, years)
+    avg_weight = float(np.mean(weight_values)) if weight_values else None
+
+    if len(weight_values) >= MIN_SURVEYS_FOR_TREND:
+        weight_years = [records[i][0] for i in range(len(records)) if not math.isnan(records[i][2])]
+        weight_trend = compute_cpue_trend(weight_values, weight_years)
+    else:
+        weight_trend = TrendStatus.INSUFFICIENT_DATA
+
+    return SpeciesTrendSummary(
+        species=species_name,
+        status=status,
+        evidence=_build_species_evidence(species_name, status, records),
+        latest_cpue=cpue_values[-1] if cpue_values else None,
+        earliest_cpue=cpue_values[0] if cpue_values else None,
+        survey_years=sorted(set(years)),
+        avg_weight_lbs=avg_weight,
+        avg_weight_trend=weight_trend,
+        best_gear=_best_gear(records),
+    )
+
+
+def analyze_water_clarity(
+    water_clarity: List[List[Union[float, str]]],
+) -> Optional[WaterClarityTrend]:
+    """Compute a Secchi disk clarity trend from SurveyOverview.water_clarity data.
+
+    Each item in water_clarity is expected to be [date_str_or_year, clarity_ft].
+    Returns None if no valid readings are found.
+    """
+    records: List[Tuple[int, float]] = []
+    for item in water_clarity:
+        if len(item) < 2:
+            continue
+        try:
+            date_str = str(item[0])
+            # Handle both ISO format "YYYY-MM-DD" and US format "MM/DD/YYYY"
+            if "/" in date_str:
+                year = int(date_str.split("/")[-1])
+            else:
+                year = int(date_str[:4])
+            clarity = float(item[1])
+        except (ValueError, TypeError):
+            continue
+        if clarity > 0:
+            records.append((year, clarity))
+    records.sort(key=lambda r: r[0])
+    if not records:
+        return None
+
+    years = [r[0] for r in records]
+    clarity_values = [r[1] for r in records]
+    status = compute_cpue_trend(clarity_values, years)
+
+    earliest_year, earliest_val = records[0]
+    latest_year, latest_val = records[-1]
+
+    if status == TrendStatus.INSUFFICIENT_DATA:
+        evidence = (
+            f"Only {len(records)} Secchi reading(s) — insufficient for trend. "
+            f"Most recent: {latest_val:.1f} ft ({latest_year})."
+        )
+    else:
+        direction = {
+            TrendStatus.INCREASING: "clearer",
+            TrendStatus.DECREASING: "murkier",
+            TrendStatus.STABLE: "stable",
+        }.get(status, "unchanged")
+        evidence = (
+            f"Water clarity {earliest_val:.1f} ft ({earliest_year}) → "
+            f"{latest_val:.1f} ft ({latest_year}): {direction} "
+            f"({len(records)} Secchi readings)."
+        )
+    return WaterClarityTrend(
+        status=status,
+        evidence=evidence,
+        recent_clarity_ft=latest_val,
+        earliest_clarity_ft=earliest_val,
+    )
+
+
+def parse_stocking_events(stocking_records: List[Dict]) -> List[StockingEvent]:
+    """Parse a list of stocking record dicts into StockingEvent objects.
+
+    Handles the variable field names produced by ``app._parse_stocking``.
+    """
+    events: List[StockingEvent] = []
+    for record in stocking_records:
+        year_raw = (
+            record.get("year")
+            or record.get("Year")
+            or record.get("YEAR")
+            or str(record.get("stocking_date", ""))[:4]
+            or str(record.get("date", ""))[:4]
+        )
+        try:
+            year = int(str(year_raw))
+        except (ValueError, TypeError):
+            continue
+
+        species = str(
+            record.get("species")
+            or record.get("Species")
+            or record.get("SPECIES")
+            or record.get("fish_species")
+            or ""
+        )
+        if not species:
+            continue
+
+        quantity_raw = (
+            record.get("quantity")
+            or record.get("Quantity")
+            or record.get("number")
+            or record.get("Number")
+        )
+        try:
+            quantity = int(str(quantity_raw).replace(",", ""))
+        except (ValueError, TypeError):
+            quantity = None
+
+        life_stage = str(
+            record.get("lifestage")
+            or record.get("life_stage")
+            or record.get("LifeStage")
+            or record.get("stage")
+            or ""
+        )
+        events.append(StockingEvent(species=species, year=year, quantity=quantity, life_stage=life_stage))
+
+    return sorted(events, key=lambda e: e.year, reverse=True)
+
+
+def analyze_lake(
+    lake_name: str,
+    survey_overview: SurveyOverview,
+    stocking_records: Optional[List[Dict]] = None,
+) -> LakeAnalysis:
+    """Run full trend analysis for all target species at a lake.
+
+    Analyzes Walleye, Northern Pike, Largemouth Bass, Black Crappie, and Sunfish
+    (only species present in surveys are included in the result).
+
+    Args:
+        lake_name: Display name of the lake.
+        survey_overview: Parsed SurveyOverview from MnDnrLakeTopographyService.
+        stocking_records: Optional list of stocking record dicts from _parse_stocking.
+
+    Returns:
+        LakeAnalysis containing per-species trends, water clarity trend,
+        and parsed stocking events.
+    """
+    surveys = survey_overview.surveys
+    species_trends: List[SpeciesTrendSummary] = []
+    for species_name, codes in TARGET_SPECIES_CODES.items():
+        summary = analyze_species_at_lake(species_name, codes, surveys)
+        if summary is not None:
+            species_trends.append(summary)
+
+    return LakeAnalysis(
+        lake_name=lake_name,
+        species_trends=species_trends,
+        water_clarity=analyze_water_clarity(survey_overview.water_clarity),
+        stocking_events=parse_stocking_events(stocking_records or []),
+    )

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,391 @@
+"""Unit tests for onkia.analysis — CPUE trend analysis module."""
+from __future__ import annotations
+
+from typing import List
+
+import pytest
+
+from onkia.analysis import (
+    MIN_SURVEYS_FOR_TREND,
+    LakeAnalysis,
+    SpeciesTrendSummary,
+    StockingEvent,
+    TrendStatus,
+    WaterClarityTrend,
+    analyze_lake,
+    analyze_species_at_lake,
+    analyze_water_clarity,
+    compute_cpue_trend,
+    parse_stocking_events,
+)
+from onkia.models import FishCatchSummary, Survey, SurveyOverview
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_survey(survey_date: str, catches: List[dict]) -> Survey:
+    """Build a Survey object from a date string and a list of catch dicts."""
+    summaries = []
+    for c in catches:
+        summaries.append(
+            FishCatchSummary(
+                species=c["species"],
+                total_catch=c.get("total_catch", 10),
+                total_weight=c.get("total_weight", 15.0),
+                cpue=str(c.get("cpue", 1.0)),
+                average_weight=str(c.get("average_weight", 1.5)),
+                gear=c.get("gear", "Standard gill nets"),
+                gear_count=c.get("gear_count", 16),
+                quartile_count="1.0-3.0",
+                quartile_weight="0.5-2.0",
+            )
+        )
+    return Survey(
+        survey_sub_type="",
+        survey_type="Standard Survey",
+        survey_date=survey_date,
+        narrative="",
+        survey_id=1,
+        fish_catch_summaries=summaries,
+    )
+
+
+def _make_overview(
+    surveys: List[Survey],
+    water_clarity: list = None,
+) -> SurveyOverview:
+    return SurveyOverview(
+        littoral_acres=500.0,
+        mean_depth_feet=15.0,
+        max_depth_feet=30,
+        area_acres=1000.0,
+        shore_length_miles=5.0,
+        water_clarity=water_clarity or [],
+        surveys=surveys,
+    )
+
+
+# ---------------------------------------------------------------------------
+# compute_cpue_trend
+# ---------------------------------------------------------------------------
+
+
+class TestComputeCpueTrend:
+    def test_insufficient_data_below_min(self):
+        assert compute_cpue_trend([1.0, 2.0], [2018, 2020]) == TrendStatus.INSUFFICIENT_DATA
+
+    def test_insufficient_data_empty(self):
+        assert compute_cpue_trend([], []) == TrendStatus.INSUFFICIENT_DATA
+
+    def test_increasing_trend(self):
+        # Clear upward slope: 1, 2, 3, 4, 5
+        assert compute_cpue_trend([1.0, 2.0, 3.0, 4.0, 5.0], [2018, 2019, 2020, 2021, 2022]) == TrendStatus.INCREASING
+
+    def test_decreasing_trend(self):
+        # Clear downward slope: 5, 4, 3, 2, 1
+        assert compute_cpue_trend([5.0, 4.0, 3.0, 2.0, 1.0], [2018, 2019, 2020, 2021, 2022]) == TrendStatus.DECREASING
+
+    def test_stable_trend(self):
+        # Nearly flat: tiny variation around 3.0
+        assert compute_cpue_trend([3.0, 3.01, 2.99, 3.0, 3.01], [2018, 2019, 2020, 2021, 2022]) == TrendStatus.STABLE
+
+    def test_exactly_min_surveys(self):
+        result = compute_cpue_trend([1.0, 2.0, 3.0], [2018, 2020, 2022])
+        assert result in (TrendStatus.INCREASING, TrendStatus.STABLE, TrendStatus.DECREASING)
+
+    def test_all_zero_cpue(self):
+        assert compute_cpue_trend([0.0, 0.0, 0.0], [2018, 2020, 2022]) == TrendStatus.STABLE
+
+    def test_custom_stability_fraction(self):
+        # With a very high threshold, a real slope should still be stable
+        result = compute_cpue_trend(
+            [1.0, 1.1, 1.2], [2018, 2020, 2022], stability_fraction=10.0
+        )
+        assert result == TrendStatus.STABLE
+
+
+# ---------------------------------------------------------------------------
+# analyze_species_at_lake
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeSpeciesAtLake:
+    def test_returns_none_when_no_matching_species(self):
+        surveys = [
+            _make_survey("2022-07-01", [{"species": "YEP", "cpue": 3.0}]),
+            _make_survey("2020-07-01", [{"species": "YEP", "cpue": 4.0}]),
+        ]
+        result = analyze_species_at_lake("Walleye", ["WAE"], surveys)
+        assert result is None
+
+    def test_returns_summary_for_matching_species(self):
+        surveys = [
+            _make_survey("2022-07-01", [{"species": "WAE", "cpue": 2.0}]),
+            _make_survey("2020-07-01", [{"species": "WAE", "cpue": 3.0}]),
+        ]
+        result = analyze_species_at_lake("Walleye", ["WAE"], surveys)
+        assert isinstance(result, SpeciesTrendSummary)
+        assert result.species == "Walleye"
+
+    def test_insufficient_data_with_two_surveys(self):
+        surveys = [
+            _make_survey("2022-07-01", [{"species": "WAE", "cpue": 2.0}]),
+            _make_survey("2020-07-01", [{"species": "WAE", "cpue": 3.0}]),
+        ]
+        result = analyze_species_at_lake("Walleye", ["WAE"], surveys)
+        assert result.status == TrendStatus.INSUFFICIENT_DATA
+
+    def test_trend_with_three_or_more_surveys(self):
+        surveys = [
+            _make_survey("2024-07-01", [{"species": "WAE", "cpue": 1.0}]),
+            _make_survey("2022-07-01", [{"species": "WAE", "cpue": 2.0}]),
+            _make_survey("2020-07-01", [{"species": "WAE", "cpue": 3.0}]),
+        ]
+        result = analyze_species_at_lake("Walleye", ["WAE"], surveys)
+        assert result.status == TrendStatus.DECREASING
+
+    def test_evidence_contains_cpue_values(self):
+        surveys = [
+            _make_survey("2024-07-01", [{"species": "WAE", "cpue": 1.0}]),
+            _make_survey("2022-07-01", [{"species": "WAE", "cpue": 2.0}]),
+            _make_survey("2020-07-01", [{"species": "WAE", "cpue": 3.0}]),
+        ]
+        result = analyze_species_at_lake("Walleye", ["WAE"], surveys)
+        assert "3.00" in result.evidence
+        assert "1.00" in result.evidence
+
+    def test_survey_years_are_sorted(self):
+        surveys = [
+            _make_survey("2024-07-01", [{"species": "NOP", "cpue": 5.0}]),
+            _make_survey("2018-07-01", [{"species": "NOP", "cpue": 3.0}]),
+            _make_survey("2021-07-01", [{"species": "NOP", "cpue": 4.0}]),
+        ]
+        result = analyze_species_at_lake("Northern Pike", ["NOP"], surveys)
+        assert result.survey_years == [2018, 2021, 2024]
+
+    def test_sunfish_aggregates_multiple_codes(self):
+        surveys = [
+            _make_survey("2024-07-01", [{"species": "BLG", "cpue": 5.0}]),
+            _make_survey("2022-07-01", [{"species": "GSF", "cpue": 4.0}]),
+            _make_survey("2020-07-01", [{"species": "BLG", "cpue": 3.0}]),
+        ]
+        result = analyze_species_at_lake("Sunfish", ["BLG", "GSF", "HSF", "PMK"], surveys)
+        assert result is not None
+        assert len(result.survey_years) == 3
+
+    def test_skips_zero_cpue(self):
+        surveys = [
+            _make_survey("2024-07-01", [{"species": "WAE", "cpue": 0.0}]),
+            _make_survey("2022-07-01", [{"species": "WAE", "cpue": 2.0}]),
+        ]
+        result = analyze_species_at_lake("Walleye", ["WAE"], surveys)
+        # Only one valid record (cpue > 0)
+        assert result.latest_cpue == 2.0
+
+    def test_best_gear_in_summary(self):
+        surveys = [
+            _make_survey("2024-07-01", [{"species": "LMB", "cpue": 3.0, "gear": "Standard trap nets"}]),
+            _make_survey("2022-07-01", [{"species": "LMB", "cpue": 2.0, "gear": "Standard trap nets"}]),
+            _make_survey("2020-07-01", [{"species": "LMB", "cpue": 1.0, "gear": "Standard gill nets"}]),
+        ]
+        result = analyze_species_at_lake("Largemouth Bass", ["LMB"], surveys)
+        assert result.best_gear == "Standard trap nets"
+
+    def test_avg_weight_computed(self):
+        surveys = [
+            _make_survey("2024-07-01", [{"species": "WAE", "cpue": 2.0, "average_weight": 2.0}]),
+            _make_survey("2022-07-01", [{"species": "WAE", "cpue": 3.0, "average_weight": 1.8}]),
+        ]
+        result = analyze_species_at_lake("Walleye", ["WAE"], surveys)
+        assert result.avg_weight_lbs is not None
+        assert abs(result.avg_weight_lbs - 1.9) < 0.01
+
+
+# ---------------------------------------------------------------------------
+# analyze_water_clarity
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeWaterClarity:
+    def test_returns_none_for_empty_input(self):
+        assert analyze_water_clarity([]) is None
+
+    def test_returns_none_for_invalid_data(self):
+        assert analyze_water_clarity([["bad", "data"]]) is None
+
+    def test_returns_trend_object(self):
+        data = [["07/21/2014", "4.5"], ["08/01/2022", "6.5"]]
+        result = analyze_water_clarity(data)
+        assert isinstance(result, WaterClarityTrend)
+
+    def test_insufficient_data_for_two_readings(self):
+        data = [["2018-01-01", "4.5"], ["2022-01-01", "5.5"]]
+        result = analyze_water_clarity(data)
+        assert result.status == TrendStatus.INSUFFICIENT_DATA
+
+    def test_increasing_clarity(self):
+        data = [
+            ["2018-01-01", "3.0"],
+            ["2020-01-01", "4.0"],
+            ["2022-01-01", "5.0"],
+            ["2024-01-01", "6.0"],
+        ]
+        result = analyze_water_clarity(data)
+        assert result.status == TrendStatus.INCREASING
+
+    def test_decreasing_clarity(self):
+        data = [
+            ["2018-01-01", "6.0"],
+            ["2020-01-01", "5.0"],
+            ["2022-01-01", "4.0"],
+            ["2024-01-01", "3.0"],
+        ]
+        result = analyze_water_clarity(data)
+        assert result.status == TrendStatus.DECREASING
+
+    def test_evidence_contains_years_and_values(self):
+        data = [
+            ["2018-01-01", "4.0"],
+            ["2020-01-01", "4.5"],
+            ["2022-01-01", "5.0"],
+        ]
+        result = analyze_water_clarity(data)
+        assert "2018" in result.evidence
+        assert "2022" in result.evidence
+
+    def test_recent_and_earliest_clarity_populated(self):
+        data = [["2018-01-01", "4.0"], ["2022-01-01", "6.0"]]
+        result = analyze_water_clarity(data)
+        assert result.earliest_clarity_ft == 4.0
+        assert result.recent_clarity_ft == 6.0
+
+    def test_skips_zero_clarity(self):
+        data = [["2018-01-01", "0.0"], ["2022-01-01", "5.0"]]
+        result = analyze_water_clarity(data)
+        assert result.earliest_clarity_ft == 5.0
+
+
+# ---------------------------------------------------------------------------
+# parse_stocking_events
+# ---------------------------------------------------------------------------
+
+
+class TestParseStockingEvents:
+    def test_returns_empty_for_empty_input(self):
+        assert parse_stocking_events([]) == []
+
+    def test_parses_basic_record(self):
+        records = [{"species": "Walleye", "year": "2022", "quantity": "50000"}]
+        events = parse_stocking_events(records)
+        assert len(events) == 1
+        assert events[0].species == "Walleye"
+        assert events[0].year == 2022
+        assert events[0].quantity == 50000
+
+    def test_quantity_handles_comma_formatting(self):
+        records = [{"species": "Walleye", "year": "2022", "quantity": "50,000"}]
+        events = parse_stocking_events(records)
+        assert events[0].quantity == 50000
+
+    def test_sorted_by_year_descending(self):
+        records = [
+            {"species": "Walleye", "year": "2018", "quantity": "10000"},
+            {"species": "Walleye", "year": "2022", "quantity": "20000"},
+            {"species": "Walleye", "year": "2015", "quantity": "5000"},
+        ]
+        events = parse_stocking_events(records)
+        assert [e.year for e in events] == [2022, 2018, 2015]
+
+    def test_skips_records_without_year(self):
+        records = [{"species": "Walleye", "quantity": "50000"}]
+        events = parse_stocking_events(records)
+        assert events == []
+
+    def test_skips_records_without_species(self):
+        records = [{"year": "2022", "quantity": "50000"}]
+        events = parse_stocking_events(records)
+        assert events == []
+
+    def test_handles_none_quantity(self):
+        records = [{"species": "Walleye", "year": "2022"}]
+        events = parse_stocking_events(records)
+        assert len(events) == 1
+        assert events[0].quantity is None
+
+
+# ---------------------------------------------------------------------------
+# analyze_lake (integration)
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeLake:
+    def _make_rich_overview(self) -> SurveyOverview:
+        surveys = [
+            _make_survey("2024-07-01", [
+                {"species": "WAE", "cpue": 1.5, "average_weight": 1.8},
+                {"species": "NOP", "cpue": 4.0, "average_weight": 3.0},
+            ]),
+            _make_survey("2022-07-01", [
+                {"species": "WAE", "cpue": 2.0, "average_weight": 1.9},
+                {"species": "NOP", "cpue": 5.0, "average_weight": 3.2},
+            ]),
+            _make_survey("2020-07-01", [
+                {"species": "WAE", "cpue": 2.5, "average_weight": 2.0},
+                {"species": "NOP", "cpue": 6.0, "average_weight": 3.5},
+            ]),
+        ]
+        return _make_overview(
+            surveys=surveys,
+            water_clarity=[["2018-01-01", "4.0"], ["2022-01-01", "5.5"]],
+        )
+
+    def test_returns_lake_analysis(self):
+        overview = self._make_rich_overview()
+        result = analyze_lake("Test Lake", overview)
+        assert isinstance(result, LakeAnalysis)
+        assert result.lake_name == "Test Lake"
+
+    def test_species_trends_only_include_present_species(self):
+        overview = self._make_rich_overview()
+        result = analyze_lake("Test Lake", overview)
+        species_names = [t.species for t in result.species_trends]
+        # Only WAE and NOP have data; LMB, BLC, Sunfish should be absent
+        assert "Walleye" in species_names
+        assert "Northern Pike" in species_names
+        assert "Largemouth Bass" not in species_names
+
+    def test_water_clarity_trend_included(self):
+        overview = self._make_rich_overview()
+        result = analyze_lake("Test Lake", overview)
+        assert result.water_clarity is not None
+
+    def test_stocking_events_parsed(self):
+        overview = self._make_rich_overview()
+        stocking = [{"species": "Walleye", "year": "2021", "quantity": "30000"}]
+        result = analyze_lake("Test Lake", overview, stocking_records=stocking)
+        assert len(result.stocking_events) == 1
+        assert result.stocking_events[0].species == "Walleye"
+
+    def test_no_stocking_records_defaults_to_empty(self):
+        overview = self._make_rich_overview()
+        result = analyze_lake("Test Lake", overview)
+        assert result.stocking_events == []
+
+    def test_empty_surveys_yields_no_species_trends(self):
+        overview = _make_overview(surveys=[])
+        result = analyze_lake("Empty Lake", overview)
+        assert result.species_trends == []
+
+    def test_walleye_decreasing_trend_detected(self):
+        surveys = [
+            _make_survey("2024-07-01", [{"species": "WAE", "cpue": 1.0}]),
+            _make_survey("2022-07-01", [{"species": "WAE", "cpue": 2.0}]),
+            _make_survey("2020-07-01", [{"species": "WAE", "cpue": 3.0}]),
+        ]
+        overview = _make_overview(surveys=surveys)
+        result = analyze_lake("Clearwater", overview)
+        wae = next(t for t in result.species_trends if t.species == "Walleye")
+        assert wae.status == TrendStatus.DECREASING


### PR DESCRIPTION
## Summary

- Adds `src/onkia/analysis.py` — a new module that computes population trend narratives for the 5 target species (Walleye, Northern Pike, Largemouth Bass, Black Crappie, Sunfish) from historical DNR survey data
- Each trend claim cites specific survey years, CPUE values, and gear type (e.g. "CPUE 3.00 → 1.00 ↓ over 2020–2024 Standard gill nets (3 survey points)")
- Adds water clarity trend analysis from Secchi disk readings and stocking event parsing from the DNR XML feed
- Integrates into `app/app.py` as a new "📈 Species Trend Analysis" section with expandable per-species cards

## Changes

- `src/onkia/analysis.py`: `TrendStatus` enum, `SpeciesTrendSummary`, `WaterClarityTrend`, `StockingEvent`, `LakeAnalysis` dataclasses; `compute_cpue_trend()` (linear regression slope), `analyze_species_at_lake()`, `analyze_water_clarity()`, `parse_stocking_events()`, `analyze_lake()` entry point
- `tests/test_analysis.py`: 41 unit tests covering all public functions
- `app/app.py`: new `_compute_trend_analysis()` cached loader and "Species Trend Analysis" UI section

## Test Plan

- [x] 41 new unit tests in `tests/test_analysis.py` — all passing
- [x] Existing 48 tests (DNR client, weather, models) unaffected
- [ ] All unit tests pass (`pytest tests/ -v` with `PYTHONPATH=src`)
- [ ] Streamlit smoke test passes (app starts and health check responds)

Closes: APR-153

🤖 Generated with [Claude Code](https://claude.com/claude-code)