### PR TITLE
Integrate USGS GLM depth-resolved lake temperature profiles (APR-156)

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -30,6 +30,13 @@ from onkia.dnr_client import MnDnrLakeTopographyService  # noqa: E402
 from onkia.water_temp import WATER_TEMP_PREFERENCES  # noqa: E402
 from onkia.models import WaterTempPreference  # noqa: E402
 from onkia.weather import get_weather_for_window, wind_direction_label  # noqa: E402
+from onkia.usgs_glm import (  # noqa: E402
+    get_temperature_profile,
+    get_thermocline_depth,
+    get_species_depth_zones,
+    has_data,
+    available_lakes,
+)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -451,6 +458,55 @@ def _build_cloud_cover_year_chart() -> plt.Figure:
     return fig
 
 
+def _c_to_f(c: float) -> float:
+    return c * 9.0 / 5.0 + 32.0
+
+
+def _m_to_ft(m: float) -> float:
+    return m * 3.28084
+
+
+def _build_depth_temp_chart(
+    profile: pd.DataFrame,
+    thermo_depth_m: Optional[float],
+    species_zones: Optional[List[Dict]],
+    lake_name: str,
+) -> plt.Figure:
+    """Depth-temperature profile chart with species preference bands."""
+    fig, ax = plt.subplots(figsize=(7, 6))
+
+    depths_ft = _m_to_ft(profile["depth_m"].values)
+    temps_f = _c_to_f(profile["temp_c"].values)
+
+    ax.plot(temps_f, depths_ft, color="#1d3557", linewidth=2.5, label="Temperature")
+
+    if thermo_depth_m is not None:
+        thermo_ft = _m_to_ft(thermo_depth_m)
+        ax.axhline(y=thermo_ft, color="#e63946", linestyle="--", linewidth=1.5,
+                    label=f"Thermocline ({thermo_ft:.1f} ft)")
+
+    if species_zones:
+        for zone in species_zones:
+            species = zone["species"]
+            color = SPECIES_COLORS.get(species, "#999999")
+            opt_low = zone.get("opt_depth_low_m")
+            opt_high = zone.get("opt_depth_high_m")
+            if opt_low is not None and opt_high is not None:
+                low_ft = _m_to_ft(opt_low)
+                high_ft = _m_to_ft(opt_high)
+                ax.axhspan(low_ft, high_ft, alpha=0.15, color=color,
+                           label=f"{species} zone ({low_ft:.0f}–{high_ft:.0f} ft)")
+
+    ax.set_xlabel("Temperature (°F)")
+    ax.set_ylabel("Depth (ft)")
+    ax.set_title(f"Depth-Temperature Profile — {lake_name}")
+    ax.invert_yaxis()
+    ax.legend(fontsize=7, loc="lower left")
+    ax.grid(True, alpha=0.3)
+    plt.tight_layout()
+    return fig
+
+
 # ---------------------------------------------------------------------------
 # Main page
 # ---------------------------------------------------------------------------
@@ -565,6 +621,13 @@ else:
 water_temp = weather.air_temp_f if weather.air_temp_f is not None else _estimate_water_temp(selected_date)
 cloud_cover = weather.cloud_cover_pct if weather.cloud_cover_pct is not None else _estimate_cloud_cover(selected_date)
 
+_usgs_lakes_check = available_lakes()
+_usgs_profile_check = None
+if _usgs_lakes_check and lake_id in _usgs_lakes_check:
+    _usgs_profile_check = get_temperature_profile(lake_id, selected_date)
+    if _usgs_profile_check is not None and len(_usgs_profile_check) > 0:
+        water_temp = _c_to_f(_usgs_profile_check.iloc[0]["temp_c"])
+
 tod = _TIME_OF_DAY_ADVICE[time_of_day]
 st.info(f"**{tod['label']}** — {tod['note']}")
 
@@ -599,6 +662,70 @@ with st.expander("📈 Seasonal Temperature & Cloud Cover Charts"):
     plt.tight_layout()
     st.pyplot(fig_combo)
     plt.close(fig_combo)
+
+# --- USGS GLM Depth-Temperature Profile ---
+_usgs_lakes = available_lakes()
+if _usgs_lakes and lake_id in _usgs_lakes:
+    st.subheader("🌊 Depth-Temperature Profile (USGS GLM)")
+
+    usgs_profile = get_temperature_profile(lake_id, selected_date)
+    usgs_thermo = get_thermocline_depth(lake_id, selected_date)
+
+    species_pref_dicts = [
+        {
+            "species": p.species,
+            "optimum": p.optimum,
+            "lower_avoidance": p.lower_avoidance,
+            "upper_avoidance": p.upper_avoidance,
+        }
+        for p in WATER_TEMP_PREFERENCES
+        if p.species in TARGET_SPECIES
+    ]
+    usgs_zones = get_species_depth_zones(lake_id, selected_date, species_pref_dicts)
+
+    if usgs_profile is not None:
+        col_depth_info, col_depth_chart = st.columns([1, 2])
+        with col_depth_info:
+            surface_c = usgs_profile.iloc[0]["temp_c"]
+            surface_f = _c_to_f(surface_c)
+            bottom_c = usgs_profile.iloc[-1]["temp_c"]
+            bottom_f = _c_to_f(bottom_c)
+            st.metric("Surface Temp", f"{surface_f:.1f}°F")
+            st.metric("Bottom Temp", f"{bottom_f:.1f}°F")
+            if usgs_thermo is not None:
+                thermo_ft = _m_to_ft(usgs_thermo)
+                st.metric("Thermocline", f"{thermo_ft:.1f} ft ({usgs_thermo:.1f} m)")
+            else:
+                st.info("No thermocline detected (isothermal or ice-covered)")
+
+            if usgs_zones:
+                zone_rows = []
+                for z in usgs_zones:
+                    low = z.get("opt_depth_low_m")
+                    high = z.get("opt_depth_high_m")
+                    zone_rows.append({
+                        "Species": z["species"],
+                        "Optimum Depth": f"{_m_to_ft(low):.0f}–{_m_to_ft(high):.0f} ft" if low and high else "N/A",
+                    })
+                st.dataframe(pd.DataFrame(zone_rows), use_container_width=True, hide_index=True)
+
+        with col_depth_chart:
+            fig_depth_temp = _build_depth_temp_chart(
+                usgs_profile, usgs_thermo, usgs_zones, lake_name,
+            )
+            st.pyplot(fig_depth_temp)
+            plt.close(fig_depth_temp)
+
+        if selected_date.year > 2021:
+            st.caption("USGS GLM data ends in 2021. Showing climatological average for this day of year.")
+    else:
+        st.info("No depth-temperature profile available for this date.")
+elif _usgs_lakes and lake_id not in _usgs_lakes:
+    with st.expander("🌊 USGS Depth-Temperature Profile"):
+        st.info("This lake is not in the USGS GLM dataset. Depth-resolved temperature is unavailable.")
+elif not _usgs_lakes:
+    with st.expander("🌊 USGS Depth-Temperature Profile"):
+        st.caption("No USGS GLM data loaded. Run `python scripts/download_usgs_glm.py --sample` to generate test data, or `python scripts/download_usgs_glm.py` to download from USGS.")
 
 # --- Species Suitability ---
 st.subheader("🐟 Species Suitability")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ streamlit = ">=1.28"
 streamlit-folium = ">=0.15"
 marimo = ">=0.11.0"
 folium = ">=0.14.0"
+xarray = ">=2023.0"
+pyarrow = ">=12.0"
+scipy = ">=1.10"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ matplotlib>=3.4.3,<4
 requests>=2.28
 pydantic>=2.0
 great-expectations>=0.18.0
+xarray>=2023.0
+pyarrow>=12.0
+scipy>=1.10

--- a/scripts/download_usgs_glm.py
+++ b/scripts/download_usgs_glm.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""Download and pre-process USGS GLM temperature data for Wright County lakes.
+
+Usage:
+    python scripts/download_usgs_glm.py [--sample] [--output-dir DIR]
+
+Modes:
+  --sample    Generate synthetic test data instead of downloading from USGS.
+              Useful for development when network access to ScienceBase is
+              unavailable.
+
+  default     Download crosswalk + metadata from ScienceBase, identify
+              Wright County lakes, extract their temperature profiles from
+              the GLM NetCDF files, and save as per-lake parquet files.
+
+Data source:
+  ScienceBase item 6206d3c2d34ec05caca53071
+  "Daily water column temperature predictions for thousands of Midwest
+   U.S. lakes between 1979-2022"
+
+Output:
+  data/usgs_glm/<dow_id>.parquet   per-lake depth-resolved daily temps
+  data/usgs_glm/crosswalk.csv       lake ID crosswalk (cached)
+  data/usgs_glm/lake_metadata.csv   lake metadata (cached)
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import logging
+import os
+import sys
+import zipfile
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s  %(message)s")
+logger = logging.getLogger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DATA_DIR = REPO_ROOT / "data" / "usgs_glm"
+
+SCIENCEBASE_ITEM = "6206d3c2d34ec05caca53071"
+
+WRIGHT_COUNTY_LAKES: Dict[str, Tuple[float, float, str]] = {
+    "Clearwater": (45.3052, -94.1184, "86025200"),
+    "Lake Pulaski": (45.2703, -94.0398, "86099900"),
+    "Lake Sylvia": (45.2853, -93.9960, "86099700"),
+    "Pelican Lake": (45.3193, -93.9085, "86099600"),
+    "Maple Lake": (45.2243, -94.0062, "86056300"),
+    "Howard Lake": (45.0618, -94.0740, "86045400"),
+    "Lake Montrose": (45.0698, -94.0169, "86063600"),
+    "Lake Andrew": (45.1437, -94.2478, "86003800"),
+    "Buffalo Lake": (45.1918, -94.2354, "86012000"),
+    "Bass Lake": (45.2531, -94.1152, "86009200"),
+    "South Center Lake": (45.3804, -93.9371, "86111700"),
+    "Lake Francis": (45.1312, -93.9812, "86040700"),
+    "Lake Charlotte": (45.1956, -93.9374, "86020400"),
+    "Twin Lake": (45.3315, -94.1987, "86120900"),
+    "Lake Ida": (45.0893, -94.2175, "86047300"),
+}
+
+DOW_IDS = {v[2] for v in WRIGHT_COUNTY_LAKES.values()}
+
+
+def _try_import_requests():
+    try:
+        import requests
+        return requests
+    except ImportError:
+        logger.error("requests is required for downloading. Install it with: pip install requests")
+        sys.exit(1)
+
+
+def _try_import_xarray():
+    try:
+        import xarray as xr
+        return xr
+    except ImportError:
+        logger.error("xarray is required for reading NetCDF. Install it with: pip install xarray")
+        sys.exit(1)
+
+
+def _sciencebase_url(item_id: str) -> str:
+    return f"https://www.sciencebase.gov/catalog/item/{item_id}?format=json"
+
+
+def download_crosswalk(requests_module) -> Optional[Path]:
+    """Download lake_id_crosswalk.csv from ScienceBase."""
+    out_path = DATA_DIR / "crosswalk.csv"
+    if out_path.exists():
+        logger.info("Crosswalk already cached at %s", out_path)
+        return out_path
+
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+    try:
+        resp = requests_module.get(_sciencebase_url(SCIENCEBASE_ITEM), timeout=60)
+        item = resp.json()
+    except Exception:
+        logger.error("Failed to fetch ScienceBase item metadata")
+        return None
+
+    for f in item.get("files", []):
+        name = f.get("name", "")
+        if "crosswalk" in name.lower() and name.endswith(".csv"):
+            url = f.get("downloadUrl", f.get("uri", ""))
+            if not url:
+                continue
+            logger.info("Downloading crosswalk from %s", url)
+            try:
+                r = requests_module.get(url, timeout=120)
+                out_path.write_bytes(r.content)
+                logger.info("Saved crosswalk → %s", out_path)
+                return out_path
+            except Exception:
+                logger.error("Failed to download crosswalk file")
+                return None
+
+    logger.error("crosswalk CSV not found in ScienceBase item files")
+    return None
+
+
+def download_metadata(requests_module) -> Optional[Path]:
+    """Download lake_metadata.csv from ScienceBase."""
+    out_path = DATA_DIR / "lake_metadata.csv"
+    if out_path.exists():
+        logger.info("Metadata already cached at %s", out_path)
+        return out_path
+
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+    try:
+        resp = requests_module.get(_sciencebase_url(SCIENCEBASE_ITEM), timeout=60)
+        item = resp.json()
+    except Exception:
+        logger.error("Failed to fetch ScienceBase item metadata")
+        return None
+
+    for f in item.get("files", []):
+        name = f.get("name", "")
+        if "metadata" in name.lower() and name.endswith(".csv"):
+            url = f.get("downloadUrl", f.get("uri", ""))
+            if not url:
+                continue
+            logger.info("Downloading metadata from %s", url)
+            try:
+                r = requests_module.get(url, timeout=120)
+                out_path.write_bytes(r.content)
+                logger.info("Saved metadata → %s", out_path)
+                return out_path
+            except Exception:
+                logger.error("Failed to download metadata file")
+                return None
+
+    logger.error("metadata CSV not found in ScienceBase item files")
+    return None
+
+
+def find_matching_site_ids(crosswalk_path: Path) -> Dict[str, str]:
+    """Map DOW IDs to USGS site_ids via the crosswalk file.
+
+    Returns {dow_id: site_id} for Wright County lakes found in the data.
+    """
+    import pandas as pd
+
+    df = pd.read_csv(crosswalk_path)
+    mndow_col = None
+    for col in df.columns:
+        if "mndow" in col.lower() or "dow" in col.lower():
+            mndow_col = col
+            break
+
+    if mndow_col is None:
+        logger.error("No MNDOW column found in crosswalk. Columns: %s", list(df.columns))
+        return {}
+
+    site_col = None
+    for col in df.columns:
+        if "site_id" in col.lower() or "siteid" in col.lower():
+            site_col = col
+            break
+    if site_col is None:
+        logger.error("No site_id column found in crosswalk. Columns: %s", list(df.columns))
+        return {}
+
+    df[mndow_col] = df[mndow_col].astype(str).str.strip()
+
+    mapping: Dict[str, str] = {}
+    for dow_id in DOW_IDS:
+        matches = df[df[mndow_col].str.contains(dow_id, na=False, regex=False)]
+        if not matches.empty:
+            site_id = str(matches.iloc[0][site_col])
+            mapping[dow_id] = site_id
+            lake_name = [n for n, v in WRIGHT_COUNTY_LAKES.items() if v[2] == dow_id]
+            logger.info("  %s (DOW %s) → site_id %s", lake_name[0] if lake_name else "?", dow_id, site_id)
+        else:
+            logger.warning("  DOW %s not found in crosswalk", dow_id)
+
+    return mapping
+
+
+def download_netcdf_data(
+    requests_module,
+    site_ids: Dict[str, str],
+    model: str = "GLM",
+) -> bool:
+    """Download and extract temperature NetCDF data for matched lakes.
+
+    Returns True if any lake data was extracted successfully.
+    """
+    import pandas as pd
+    import tempfile
+
+    try:
+        resp = requests_module.get(_sciencebase_url(SCIENCEBASE_ITEM), timeout=60)
+        item = resp.json()
+    except Exception:
+        logger.error("Failed to fetch ScienceBase item metadata for NetCDF download")
+        return False
+
+    zip_name_pattern = f"lake_temp_preds_{model}_NLDAS"
+    zip_url = None
+    for f in item.get("files", []):
+        name = f.get("name", "")
+        if zip_name_pattern in name and name.endswith(".zip"):
+            zip_url = f.get("downloadUrl", f.get("uri", ""))
+            break
+
+    if not zip_url:
+        logger.error("%s NetCDF zip not found in ScienceBase files", model)
+        return False
+
+    logger.info("Downloading %s zip from %s (this may take a while)...", model, zip_url)
+
+    target_sites = set(site_ids.values())
+    if not target_sites:
+        logger.warning("No matched site IDs — nothing to extract")
+        return False
+
+    try:
+        r = requests_module.get(zip_url, timeout=600, stream=True)
+        tmp_zip = tempfile.NamedTemporaryFile(suffix=".zip", delete=False)
+        for chunk in r.iter_content(chunk_size=8192):
+            tmp_zip.write(chunk)
+        tmp_zip.close()
+        zip_path = tmp_zip.name
+    except Exception:
+        logger.error("Failed to download NetCDF zip")
+        return False
+
+    extracted = 0
+    try:
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            nc_files = [n for n in zf.namelist() if n.endswith(".nc")]
+            logger.info("NetCDF zip contains %d .nc files", len(nc_files))
+
+            xr = _try_import_xarray()
+            for nc_name in nc_files:
+                with zf.open(nc_name) as f:
+                    try:
+                        ds = xr.open_dataset(io.BytesIO(f.read()))
+                    except Exception:
+                        logger.warning("Failed to open %s", nc_name)
+                        continue
+
+                    if "site_id" not in ds.coords and "site_id" not in ds.dims:
+                        ds.close()
+                        continue
+
+                    site_ids_in_file = ds.coords.get("site_id", ds.dims.get("site_id"))
+                    if site_ids_in_file is None:
+                        ds.close()
+                        continue
+
+                    ids_values = set(str(v) for v in site_ids_in_file.values)
+                    matched = ids_values & target_sites
+                    if not matched:
+                        ds.close()
+                        continue
+
+                    for sid in matched:
+                        dow_id = next(k for k, v in site_ids.items() if v == sid)
+                        try:
+                            sub = ds.sel(site_id=sid)
+                            df = sub.to_dataframe().reset_index()
+                            df = df.rename(columns={
+                                "depth": "depth_m",
+                                "temp": "temp_c",
+                            })
+                            if "time" in df.columns:
+                                df = df.rename(columns={"time": "date"})
+                            df = df[["date", "depth_m", "temp_c"]].dropna(subset=["temp_c"])
+                            out_path = DATA_DIR / f"{dow_id}.parquet"
+                            df.to_parquet(out_path, index=False)
+                            lake_name = [n for n, v in WRIGHT_COUNTY_LAKES.items() if v[2] == dow_id]
+                            logger.info(
+                                "  Extracted %s (%s): %d rows → %s",
+                                lake_name[0] if lake_name else "?", dow_id, len(df), out_path,
+                            )
+                            extracted += 1
+                        except Exception:
+                            logger.warning("  Failed to extract site_id=%s", sid, exc_info=True)
+
+                    ds.close()
+    finally:
+        os.unlink(zip_path)
+
+    logger.info("Extracted data for %d lakes", extracted)
+    return extracted > 0
+
+
+def generate_sample_data(output_dir: Optional[Path] = None) -> None:
+    """Generate synthetic test data for all Wright County lakes."""
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+    from onkia.usgs_glm import generate_sample_data as _gen
+
+    out = output_dir or DATA_DIR
+    out.mkdir(parents=True, exist_ok=True)
+
+    for name, (lat, lon, dow) in WRIGHT_COUNTY_LAKES.items():
+        max_depth_map = {
+            "Clearwater": 25, "Lake Pulaski": 18, "Lake Sylvia": 19,
+            "Pelican Lake": 14, "Maple Lake": 12, "Howard Lake": 9,
+            "Lake Montrose": 8, "Lake Andrew": 22, "Buffalo Lake": 10,
+            "Bass Lake": 11, "South Center Lake": 20, "Lake Francis": 15,
+            "Lake Charlotte": 8, "Twin Lake": 10, "Lake Ida": 16,
+        }
+        max_depth = max_depth_map.get(name, 15.0)
+        _gen(dow, name, max_depth, lat, output_dir=out)
+        logger.info("  Generated sample data for %s (DOW %s)", name, dow)
+
+    logger.info("Sample data generation complete — %d lakes", len(WRIGHT_COUNTY_LAKES))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Download USGS GLM temperature data for Wright County lakes")
+    parser.add_argument("--sample", action="store_true", help="Generate synthetic test data instead of downloading")
+    parser.add_argument("--output-dir", type=Path, default=None, help="Override output directory")
+    args = parser.parse_args()
+
+    out_dir = args.output_dir or DATA_DIR
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.sample:
+        logger.info("=== Generating synthetic sample data ===")
+        generate_sample_data(output_dir=out_dir)
+        return
+
+    logger.info("=== Downloading USGS GLM data from ScienceBase ===")
+    requests = _try_import_requests()
+
+    cw_path = download_crosswalk(requests)
+    if cw_path is None:
+        logger.error("Cannot proceed without crosswalk file. Use --sample for test data.")
+        sys.exit(1)
+
+    mapping = find_matching_site_ids(cw_path)
+    if not mapping:
+        logger.warning("No Wright County lakes matched in crosswalk. Trying EA-LSTM model.")
+        success = download_netcdf_data(requests, {}, model="EALSTM")
+        if not success:
+            logger.error("No data extracted. Use --sample for test data.")
+            sys.exit(1)
+        return
+
+    logger.info("Matched %d Wright County lakes in crosswalk", len(mapping))
+
+    meta_path = download_metadata(requests)
+    if meta_path:
+        logger.info("Lake metadata cached at %s", meta_path)
+
+    success = download_netcdf_data(requests, mapping, model="GLM")
+    if not success:
+        logger.warning("GLM extraction failed — trying EA-LSTM model (broader coverage)")
+        success = download_netcdf_data(requests, mapping, model="EALSTM")
+
+    if success:
+        logger.info("Data download and extraction complete.")
+    else:
+        logger.error("Failed to extract any lake data. Use --sample for test data.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/onkia/usgs_glm.py
+++ b/src/onkia/usgs_glm.py
@@ -1,0 +1,332 @@
+"""USGS GLM depth-resolved lake temperature profiles.
+
+Loads pre-processed USGS General Lake Model (GLM) temperature data
+stored as per-lake parquet files in ``data/usgs_glm/``.  Falls back
+gracefully when data is unavailable.
+
+Each parquet file is named by DOW ID (e.g. ``86025200.parquet``) and
+contains columns: ``date``, ``depth_m``, ``temp_c``.
+
+Public API
+----------
+get_temperature_profile  - depth vs temperature for a given date
+get_thermocline_depth    - thermocline depth in metres
+get_climatological_profile - day-of-year average profile
+get_species_depth_zones  - map species preferences to depth ranges
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+_DATA_DIR = Path(__file__).resolve().parent.parent.parent / "data" / "usgs_glm"
+
+_THERMOCLINE_GRADIENT_THRESHOLD = 1.0
+
+
+def _parquet_path(dow_id: str) -> Path:
+    return _DATA_DIR / f"{dow_id}.parquet"
+
+
+def _load_lake_data(dow_id: str) -> Optional[pd.DataFrame]:
+    path = _parquet_path(dow_id)
+    if not path.exists():
+        return None
+    try:
+        df = pd.read_parquet(path)
+        required = {"date", "depth_m", "temp_c"}
+        if not required.issubset(df.columns):
+            logger.warning("Parquet for %s missing columns %s", dow_id, required - set(df.columns))
+            return None
+        df["date"] = pd.to_datetime(df["date"])
+        return df
+    except Exception:
+        logger.warning("Failed to read parquet for %s", dow_id, exc_info=True)
+        return None
+
+
+def available_lakes() -> List[str]:
+    """Return DOW IDs that have pre-processed USGS GLM data."""
+    if not _DATA_DIR.exists():
+        return []
+    return sorted(
+        p.stem for p in _DATA_DIR.glob("*.parquet")
+    )
+
+
+def has_data(dow_id: str) -> bool:
+    return _parquet_path(dow_id).exists()
+
+
+def get_temperature_profile(
+    dow_id: str,
+    query_date: date,
+) -> Optional[pd.DataFrame]:
+    """Return depth-resolved temperature profile for *query_date*.
+
+    If the exact date is not in the dataset (e.g. post-2022), the
+    climatological average for that day-of-year is used instead.
+
+    Returns a DataFrame with columns ``depth_m``, ``temp_c`` sorted by
+    depth ascending, or ``None`` if the lake has no USGS data.
+    """
+    df = _load_lake_data(dow_id)
+    if df is None:
+        return None
+
+    exact = df[df["date"].dt.date == query_date]
+    if not exact.empty:
+        profile = (
+            exact.groupby("depth_m")["temp_c"]
+            .mean()
+            .reset_index()
+            .sort_values("depth_m")
+        )
+        return profile
+
+    doy = query_date.timetuple().tm_yday
+    return get_climatological_profile(dow_id, doy)
+
+
+def get_climatological_profile(
+    dow_id: str,
+    day_of_year: int,
+) -> Optional[pd.DataFrame]:
+    """Day-of-year climatological mean profile from 1980-2021 data.
+
+    Uses a +/-7 day window around the target day-of-year to smooth
+    interannual variability.
+    """
+    df = _load_lake_data(dow_id)
+    if df is None:
+        return None
+
+    df["doy"] = df["date"].dt.dayofyear
+
+    window_low = max(day_of_year - 7, 1)
+    window_high = min(day_of_year + 7, 366)
+
+    if window_low <= window_high:
+        subset = df[(df["doy"] >= window_low) & (df["doy"] <= window_high)]
+    else:
+        subset = pd.concat([
+            df[df["doy"] >= window_low],
+            df[df["doy"] <= window_high],
+        ])
+
+    if subset.empty:
+        return None
+
+    profile = (
+        subset.groupby("depth_m")["temp_c"]
+        .mean()
+        .reset_index()
+        .sort_values("depth_m")
+    )
+    return profile
+
+
+def get_thermocline_depth(
+    dow_id: str,
+    query_date: date,
+) -> Optional[float]:
+    """Compute thermocline depth (metres) for *query_date*.
+
+    The thermocline is defined as the depth of maximum vertical
+    temperature gradient, provided that gradient exceeds
+    ``_THERMOCLINE_GRADIENT_THRESHOLD`` (1 °C/m).  Returns ``None``
+    if the lake has no data or no thermocline is detectable (e.g.
+    isothermal or ice-covered conditions).
+    """
+    profile = get_temperature_profile(dow_id, query_date)
+    if profile is None or len(profile) < 3:
+        return None
+
+    depths = profile["depth_m"].values
+    temps = profile["temp_c"].values
+
+    gradients = np.abs(np.diff(temps)) / np.diff(depths)
+    if gradients.size == 0:
+        return None
+
+    max_idx = int(np.argmax(gradients))
+    max_gradient = gradients[max_idx]
+
+    if max_gradient < _THERMOCLINE_GRADIENT_THRESHOLD:
+        return None
+
+    thermo_depth = 0.5 * (depths[max_idx] + depths[max_idx + 1])
+    return float(thermo_depth)
+
+
+def _f_to_c(temp_f: float) -> float:
+    return (temp_f - 32.0) * 5.0 / 9.0
+
+
+def _c_to_f(temp_c: float) -> float:
+    return temp_c * 9.0 / 5.0 + 32.0
+
+
+def _parse_optimum_range(optimum_str: str) -> Tuple[float, float]:
+    """Parse optimum temperature string to (low_c, high_c) in Celsius."""
+    try:
+        if "-" in optimum_str:
+            parts = optimum_str.split("-")
+            low_f, high_f = float(parts[0]), float(parts[1])
+        else:
+            low_f = high_f = float(optimum_str)
+        return _f_to_c(low_f), _f_to_c(high_f)
+    except (ValueError, AttributeError):
+        return (0.0, 100.0)
+
+
+def get_species_depth_zones(
+    dow_id: str,
+    query_date: date,
+    species_prefs: List[dict],
+) -> Optional[List[Dict]]:
+    """Map species temperature preferences to depth zones.
+
+    Each entry in *species_prefs* must have keys ``species``, ``optimum``
+    (a temperature string in °F, possibly a range like ``"64-70"``),
+    ``lower_avoidance`` (°F or None), and ``upper_avoidance`` (°F or
+    None).
+
+    Returns a list of dicts:
+    ``species, opt_temp_c, opt_depth_low_m, opt_depth_high_m,
+    thermo_depth_m`` or ``None`` if the lake has no USGS data.
+    """
+    profile = get_temperature_profile(dow_id, query_date)
+    if profile is None:
+        return None
+
+    thermo = get_thermocline_depth(dow_id, query_date)
+    depths = profile["depth_m"].values
+    temps = profile["temp_c"].values
+
+    zones: List[Dict] = []
+    for pref in species_prefs:
+        species = pref.get("species", "")
+        opt_low_c, opt_high_c = _parse_optimum_range(str(pref.get("optimum", "")))
+
+        mask = (temps >= opt_low_c) & (temps <= opt_high_c)
+        if not mask.any():
+            zones.append({
+                "species": species,
+                "opt_temp_c": (opt_low_c + opt_high_c) / 2,
+                "opt_depth_low_m": None,
+                "opt_depth_high_m": None,
+                "thermo_depth_m": thermo,
+            })
+            continue
+
+        matching_depths = depths[mask]
+        zones.append({
+            "species": species,
+            "opt_temp_c": (opt_low_c + opt_high_c) / 2,
+            "opt_depth_low_m": float(matching_depths.min()),
+            "opt_depth_high_m": float(matching_depths.max()),
+            "thermo_depth_m": thermo,
+        })
+
+    return zones
+
+
+def generate_sample_data(
+    dow_id: str,
+    lake_name: str,
+    max_depth_m: float,
+    lat: float,
+    output_dir: Optional[Path] = None,
+) -> Path:
+    """Generate synthetic temperature data for testing / demo.
+
+    Produces a physically plausible depth-resolved temperature
+    climatology for a dimictic Minnesota lake.  NOT a substitute for
+    real USGS data — only for development and testing.
+    """
+    import warnings
+
+    warnings.warn(
+        "generate_sample_data produces synthetic data for testing only",
+        stacklevel=2,
+    )
+
+    out_dir = output_dir or _DATA_DIR
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    doy_range = np.arange(1, 367)
+    depths = np.array([0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0,
+                        6.0, 7.0, 8.0, 9.0, 10.0, 12.0, 14.0, 16.0, 18.0,
+                        20.0, 25.0, 30.0, 35.0, 40.0])
+    depths = depths[depths <= max_depth_m]
+
+    rows = []
+    year = 2021
+    for doy in doy_range:
+        d = date(year, 1, 1) + timedelta(days=int(doy) - 1)
+
+        surface_temp = _dimictic_surface_temp(doy, lat)
+        for depth in depths:
+            temp = _temperature_at_depth(surface_temp, depth, doy, lat)
+            if temp is not None and not np.isnan(temp):
+                rows.append({
+                    "date": d.isoformat(),
+                    "depth_m": round(float(depth), 2),
+                    "temp_c": round(float(temp), 2),
+                })
+
+    df = pd.DataFrame(rows)
+    out_path = out_dir / f"{dow_id}.parquet"
+    df.to_parquet(out_path, index=False)
+    logger.info("Wrote synthetic data for %s (%s) → %s", lake_name, dow_id, out_path)
+    return out_path
+
+
+def _dimictic_surface_temp(doy: int, lat: float) -> float:
+    """Approximate surface temperature for a dimictic lake by day-of-year."""
+    peak_doy = 200
+    amplitude = 24.0
+    mean_annual = 8.0
+
+    if doy < 90 or doy > 355:
+        return 1.0
+    if doy < 120:
+        return 1.0 + (doy - 90) * 0.07
+    if doy > 330:
+        return 1.0 + (355 - doy) * 0.1
+
+    day_angle = 2.0 * np.pi * (doy - peak_doy) / 365.0
+    return mean_annual + amplitude * np.cos(day_angle) * 0.5
+
+
+def _temperature_at_depth(
+    surface_temp: float,
+    depth: float,
+    doy: int,
+    lat: float,
+) -> float:
+    """Estimate temperature at a given depth from surface temp and season."""
+    if surface_temp <= 2.0:
+        return max(surface_temp - 0.1 * depth, 0.5)
+
+    is_stratified = surface_temp > 15.0 and 120 < doy < 300
+
+    if is_stratified:
+        thermo_depth = 5.0 + 2.0 * np.sin(2.0 * np.pi * (doy - 180) / 365.0)
+        hypolimnion_temp = 5.0 + 1.5 * np.sin(2.0 * np.pi * (doy - 200) / 365.0)
+
+        if depth <= thermo_depth:
+            return surface_temp - (surface_temp - hypolimnion_temp) * (depth / thermo_depth) ** 1.5
+        else:
+            return hypolimnion_temp + 0.3 * (depth - thermo_depth) * 0.01
+    else:
+        cooling_rate = 0.15 if surface_temp > 8.0 else 0.05
+        return surface_temp - cooling_rate * depth

--- a/tests/test_app_smoke.py
+++ b/tests/test_app_smoke.py
@@ -78,6 +78,25 @@ def test_onkia_importable() -> None:
     assert callable(get_weather_for_window)
 
 
+def test_onkia_usgs_glm_importable() -> None:
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+    try:
+        from onkia.usgs_glm import (
+            get_temperature_profile,
+            get_thermocline_depth,
+            get_species_depth_zones,
+            get_climatological_profile,
+            available_lakes,
+            has_data,
+        )
+    except ModuleNotFoundError as exc:
+        pytest.skip(f"Missing runtime dep: {exc.name}")
+    assert callable(get_temperature_profile)
+    assert callable(get_thermocline_depth)
+    assert callable(get_species_depth_zones)
+    assert callable(available_lakes)
+
+
 def test_onkia_models_importable() -> None:
     sys.path.insert(0, str(REPO_ROOT / "src"))
     try:
@@ -124,6 +143,13 @@ def test_app_has_time_of_day_selector() -> None:
 def test_app_has_depth_profile() -> None:
     source = (APP_DIR / "app.py").read_text()
     assert "depth_profile" in source.lower() or "depth" in source.lower()
+
+
+def test_app_has_usgs_glm_integration() -> None:
+    source = (APP_DIR / "app.py").read_text()
+    assert "usgs_glm" in source.lower() or "get_temperature_profile" in source
+    assert "thermocline" in source.lower()
+    assert "species_depth_zones" in source.lower() or "depth_temp" in source.lower()
 
 
 def test_app_has_historical_temp_chart() -> None:

--- a/tests/test_usgs_glm.py
+++ b/tests/test_usgs_glm.py
@@ -1,0 +1,195 @@
+"""Tests for onkia.usgs_glm — USGS GLM depth-resolved temperature profiles."""
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+from datetime import date
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+_src = Path(__file__).resolve().parent.parent / "src"
+if str(_src) not in sys.path:
+    sys.path.insert(0, str(_src))
+
+from onkia.usgs_glm import (
+    available_lakes,
+    generate_sample_data,
+    get_climatological_profile,
+    get_species_depth_zones,
+    get_temperature_profile,
+    get_thermocline_depth,
+    has_data,
+    _c_to_f,
+    _f_to_c,
+    _parse_optimum_range,
+)
+
+
+@pytest.fixture
+def tmp_data_dir(tmp_path):
+    d = tmp_path / "usgs_glm"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def sample_lake_parquet(tmp_data_dir):
+    """Write a small parquet file mimicking USGS GLM output."""
+    rows = []
+    base = date(2021, 6, 15)
+    for day_offset in range(-14, 15):
+        d = date(2021, 6, 15) + __import__("datetime").timedelta(days=day_offset)
+        for depth_m in [0.5, 1.0, 2.0, 3.0, 5.0, 7.0, 10.0, 15.0, 20.0]:
+            surface = 22.0
+            if depth_m <= 6.0:
+                temp = surface - 1.5 * depth_m
+            else:
+                temp = 5.0
+            if day_offset > 0:
+                surface += 0.3 * day_offset
+            rows.append({
+                "date": d.isoformat(),
+                "depth_m": depth_m,
+                "temp_c": round(temp, 2),
+            })
+    df = pd.DataFrame(rows)
+    out = tmp_data_dir / "86025200.parquet"
+    df.to_parquet(out, index=False)
+    return out
+
+
+@pytest.fixture
+def patched_data_dir(sample_lake_parquet, monkeypatch):
+    import onkia.usgs_glm as mod
+    monkeypatch.setattr(mod, "_DATA_DIR", sample_lake_parquet.parent)
+
+
+class TestUnitConversions:
+    def test_c_to_f(self):
+        assert _c_to_f(0.0) == 32.0
+        assert _c_to_f(100.0) == 212.0
+        assert abs(_c_to_f(20.0) - 68.0) < 0.01
+
+    def test_f_to_c(self):
+        assert _f_to_c(32.0) == 0.0
+        assert _f_to_c(212.0) == 100.0
+        assert abs(_f_to_c(68.0) - 20.0) < 0.01
+
+    def test_round_trip(self):
+        for t_c in [-10.0, 0.0, 15.0, 30.0]:
+            assert abs(_c_to_f(_f_to_c(t_c)) - t_c) < 0.001
+
+    def test_parse_optimum_single(self):
+        low, high = _parse_optimum_range("64")
+        assert low == pytest.approx(_f_to_c(64.0))
+        assert high == pytest.approx(_f_to_c(64.0))
+
+    def test_parse_optimum_range(self):
+        low, high = _parse_optimum_range("64-70")
+        assert low == pytest.approx(_f_to_c(64.0))
+        assert high == pytest.approx(_f_to_c(70.0))
+
+
+class TestAvailableLakes:
+    def test_available_lakes_empty(self, tmp_data_dir, monkeypatch):
+        import onkia.usgs_glm as mod
+        monkeypatch.setattr(mod, "_DATA_DIR", tmp_data_dir)
+        empty = tmp_data_dir / "empty_sub"
+        empty.mkdir()
+        monkeypatch.setattr(mod, "_DATA_DIR", empty)
+        assert available_lakes() == []
+
+    def test_available_lakes_with_data(self, patched_data_dir):
+        lakes = available_lakes()
+        assert "86025200" in lakes
+
+    def test_has_data(self, patched_data_dir):
+        assert has_data("86025200") is True
+        assert has_data("99999999") is False
+
+
+class TestGetTemperatureProfile:
+    def test_exact_date(self, patched_data_dir):
+        profile = get_temperature_profile("86025200", date(2021, 6, 15))
+        assert profile is not None
+        assert "depth_m" in profile.columns
+        assert "temp_c" in profile.columns
+        assert len(profile) > 0
+        assert profile["depth_m"].is_monotonic_increasing
+
+    def test_post_2022_uses_climatology(self, patched_data_dir):
+        profile = get_temperature_profile("86025200", date(2025, 6, 15))
+        assert profile is not None
+        assert len(profile) > 0
+
+    def test_no_data_lake(self, patched_data_dir):
+        profile = get_temperature_profile("99999999", date(2021, 6, 15))
+        assert profile is None
+
+
+class TestGetClimatologicalProfile:
+    def test_climatology(self, patched_data_dir):
+        profile = get_climatological_profile("86025200", 166)
+        assert profile is not None
+        assert len(profile) > 0
+
+    def test_climatology_no_data(self, patched_data_dir):
+        profile = get_climatological_profile("99999999", 166)
+        assert profile is None
+
+
+class TestGetThermoclineDepth:
+    def test_thermocline_detected(self, patched_data_dir):
+        thermo = get_thermocline_depth("86025200", date(2021, 6, 15))
+        if thermo is not None:
+            assert 1.0 <= thermo <= 20.0
+
+    def test_thermocline_no_data(self, patched_data_dir):
+        thermo = get_thermocline_depth("99999999", date(2021, 6, 15))
+        assert thermo is None
+
+
+class TestGetSpeciesDepthZones:
+    def test_species_zones(self, patched_data_dir):
+        prefs = [
+            {"species": "Walleye", "optimum": "64-70", "lower_avoidance": 50, "upper_avoidance": 76},
+            {"species": "Northern Pike", "optimum": "65", "lower_avoidance": 55, "upper_avoidance": 74},
+        ]
+        zones = get_species_depth_zones("86025200", date(2021, 6, 15), prefs)
+        assert zones is not None
+        assert len(zones) == 2
+        assert zones[0]["species"] == "Walleye"
+        assert "opt_depth_low_m" in zones[0]
+        assert "thermo_depth_m" in zones[0]
+
+    def test_species_zones_no_data(self, patched_data_dir):
+        prefs = [{"species": "Walleye", "optimum": "64-70", "lower_avoidance": 50, "upper_avoidance": 76}]
+        zones = get_species_depth_zones("99999999", date(2021, 6, 15), prefs)
+        assert zones is None
+
+
+class TestGenerateSampleData:
+    def test_generates_parquet(self, tmp_data_dir, monkeypatch):
+        import onkia.usgs_glm as mod
+        monkeypatch.setattr(mod, "_DATA_DIR", tmp_data_dir)
+        out = generate_sample_data("86025200", "Clearwater", 25.0, 45.3, output_dir=tmp_data_dir)
+        assert out.exists()
+        df = pd.read_parquet(out)
+        assert {"date", "depth_m", "temp_c"}.issubset(df.columns)
+        assert len(df) > 0
+        assert df["depth_m"].max() <= 25.0
+
+    def test_generate_all_wright_county(self, tmp_data_dir, monkeypatch):
+        import onkia.usgs_glm as mod
+        monkeypatch.setattr(mod, "_DATA_DIR", tmp_data_dir)
+        from scripts.download_usgs_glm import WRIGHT_COUNTY_LAKES
+
+        for name, (lat, lon, dow) in WRIGHT_COUNTY_LAKES.items():
+            generate_sample_data(dow, name, 15.0, lat, output_dir=tmp_data_dir)
+
+        lakes = available_lakes()
+        assert len(lakes) == len(WRIGHT_COUNTY_LAKES)


### PR DESCRIPTION
## Summary

Implements [APR-156](mention://issue/878b5493-edf4-4584-a3f7-eebf3ad4c78c) — USGS General Lake Model depth-resolved temperature profile integration for Wright County lakes.

### Changes

**New module: `src/onkia/usgs_glm.py`**
- `get_temperature_profile(dow_id, date)` — returns depth vs temperature for a given date
- `get_thermocline_depth(dow_id, date)` — detects thermocline via max temperature gradient (>1°C/m threshold)
- `get_climatological_profile(dow_id, day_of_year)` — day-of-year average for dates after 2022
- `get_species_depth_zones(dow_id, date, species_prefs)` — maps species temperature preferences to depth ranges
- `generate_sample_data()` — synthetic dimictic lake profiles for testing
- Graceful fallback when lake data is unavailable

**Data prep script: `scripts/download_usgs_glm.py`**
- `--sample` mode generates synthetic test data for all 15 Wright County lakes
- Default mode downloads crosswalk/metadata from ScienceBase, extracts temperature data from NetCDF
- Falls back to EA-LSTM model if GLM coverage is sparse

**App integration (`app/app.py`)**
- Depth-temperature profile chart with thermocline depth indicator
- Species preference depth zone bands overlaid on chart
- Surface temp sourced from USGS data when available (overrides weather API estimate)
- Informative messages for lakes not in dataset or when no data is loaded

**Dependencies added:** xarray, pyarrow, scipy

**Tests:** 19 unit tests + 2 smoke tests — all 37 passing

### Acceptance criteria
- [x] Temperature-depth profile displayed for lakes in the USGS dataset
- [x] Thermocline depth identified and displayed
- [x] Species preferred depth zones shown on the profile chart
- [x] Graceful handling of lakes not in the dataset