### PR TITLE
fix: mark Home page as default to resolve empty url_path error

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -73,7 +73,7 @@ def home():
 
 page = st.navigation({
     "Hub": [
-        st.Page(home, title="Home", url_path=""),
+        st.Page(home, title="Home", url_path="", default=True),
     ],
     "Apps": [
         st.Page("pages/fishing.py", title="Fishing Intelligence", icon=":material/fishing:", url_path="fishing"),


### PR DESCRIPTION
## Summary
- Adds `default=True` to the Home `st.Page()` call in `app/app.py`
- Streamlit tightened validation so `url_path=""` now requires the page to be explicitly marked as the default page

## Test plan
- [ ] Deploy to Streamlit Cloud and confirm the app loads without the `StreamlitAPIException`
- [ ] Verify Home page renders at the root URL path
- [ ] Verify the Fishing Intelligence page still navigates correctly at `/fishing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)