### PR TITLE
fix: remove sys.path mutation in app/app.py (APR-122)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -57,7 +57,6 @@ jobs:
         run: |
           python -c "
           import importlib.util, sys
-          sys.path.insert(0, 'src')
           import onkia
           from onkia.dnr_client import MnDnrLakeTopographyService
           from onkia.water_temp import WATER_TEMP_PREFERENCES
@@ -72,6 +71,8 @@ jobs:
   streamlit-smoke:
     name: Streamlit Smoke Test
     runs-on: ubuntu-latest
+    env:
+      PYTHONPATH: src
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ export
 
 .PHONY: install
 install:
-	poetry install --no-root
+	poetry install
+	pip install -e .
 
 .env:
 	echo "" > .env

--- a/app/app.py
+++ b/app/app.py
@@ -3,18 +3,16 @@
 Multi-page app with a generic landing page and pluggable modules.
 Run with:
 
+    pip install -e .
     streamlit run app/app.py
+
+Or without installing the package:
+
+    PYTHONPATH=src streamlit run app/app.py
 """
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
 import streamlit as st
-
-_src = Path(__file__).resolve().parent.parent / "src"
-if str(_src) not in sys.path:
-    sys.path.insert(0, str(_src))
 
 st.set_page_config(
     page_title="AprovanLabs",

--- a/app/pages/fishing.py
+++ b/app/pages/fishing.py
@@ -1,16 +1,15 @@
 """Fishing Intelligence — Wright County, MN.
 
 Loaded as a page inside the AprovanLabs Data Science hub.
+Requires onkia package installed (pip install -e .) or PYTHONPATH=src.
 Run the hub with:
 
     streamlit run app/app.py
 """
 from __future__ import annotations
 
-import sys
 import xml.etree.ElementTree as ET
 from datetime import date, time, timedelta
-from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 import matplotlib.pyplot as plt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,9 @@ name = "aprovan_data_science"
 description = "Core data science repository"
 authors = []
 version = "0.1.0"
+packages = [
+    { include = "onkia", from = "src" },
+]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
@@ -29,4 +32,8 @@ black = {version = "^23.7", allow-prereleases = true}
 
 [tool.poetry.group.dev.dependencies]
 ipykernel = "^6.23.3"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
 


### PR DESCRIPTION
## Summary

Removes the `sys.path.insert` boundary purity leak flagged by desloppify (APR-118 → APR-122) in `app/app.py`.

### Changes
- **`app/app.py`**: Removed `sys`/`Path` imports and the `sys.path.insert(0, ...)` hack. Updated docstring to document `pip install -e .` and `PYTHONPATH=src` alternatives.
- **`app/pages/fishing.py`**: Removed unused `sys` and `Path` imports. Added install requirement note to docstring.
- **`pyproject.toml`**: Added `packages = [{ include = "onkia", from = "src" }]` and `[build-system]` section so `pip install -e .` installs the `onkia` package.
- **`Makefile`**: Updated `install` target to run `poetry install` + `pip install -e .`.
- **`.github/workflows/validate.yml`**: Added `PYTHONPATH: src` to the streamlit-smoke job. Removed redundant `sys.path.insert` from the notebooks validation step.

### Verification
Desloppify scan confirms the `import_path_mutation` smell is resolved — no `sys.path` or `import_path_mutation` issues remain.

Closes APR-122