### PR TITLE
fix: replace sys.exit() with return codes in validate_data.py

### DIFF
--- a/scripts/validate_data.py
+++ b/scripts/validate_data.py
@@ -1,4 +1,3 @@
-import sys
 from pathlib import Path
 
 import pandas as pd
@@ -268,11 +267,11 @@ def main():
     print()
     if all_passed:
         print("All validations passed.")
-        sys.exit(0)
+        return 0
     else:
         print("Some validations failed.")
-        sys.exit(1)
+        return 1
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Replaces `sys.exit()` calls in `scripts/validate_data.py` main() function with return codes, resolving the desloppify `sys_exit_in_library` finding (APR-123).

## Changes
- `main()` now returns exit codes (0 for success, 1 for failure) instead of calling `sys.exit()`
- `if __name__ == "__main__"` block uses `raise SystemExit(main())` to propagate the exit code
- Removed unused `import sys`

## Validation
- Python syntax check passes
- `desloppify scan` confirms `sys_exit_in_library` detector now shows 0 open issues for this file

Closes APR-123